### PR TITLE
Feat/#44/sign up #44

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -4,14 +4,17 @@ interface Props {
   placeholder: string;
   label: string;
   id: string;
+  onChange?: (e:React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
+  error?: string;
+  disabled?: boolean;
 }
 
-function Input({ placeholder, id, label }: Props) {
-  const placeholderText = placeholder + "을 입력해 주세요";
+function Input({ placeholder, id, label, onChange, error, disabled }: Props) {
   return (
     <label htmlFor={id} className={S.inputContainer}>
       <p>{label}</p>
-      <input type="text" placeholder={placeholderText} />
+      <input type="text" placeholder={placeholder} onChange={onChange} disabled={disabled}/>
+      {error && <p className={S.errorMessage}>{error}</p>}
     </label>
   );
 }

--- a/src/components/SubmitButton.tsx
+++ b/src/components/SubmitButton.tsx
@@ -1,8 +1,10 @@
 import S from "./styles/form.module.css";
 interface Props {
   label: string;
+  type?: "button" | "submit" | "reset";
+  disabled?: boolean;
 }
-function SubmitButton({ label }: Props) {
-  return <button className={S.submitButton}>{label}</button>;
+function SubmitButton({ label, type = "button", disabled = false }: Props) {
+  return <button type={type} className={S.submitButton} disabled={disabled}>{label}</button>;
 }
 export default SubmitButton;

--- a/src/components/styles/form.module.css
+++ b/src/components/styles/form.module.css
@@ -12,7 +12,7 @@
 }
 
 .inputContainer {
-  p {
+  p:not(.errorMessage) {
     font-size: var(--font-4);
     font-weight: bold;
     margin-bottom: var(--space-0);
@@ -23,4 +23,11 @@
     border-radius: var(--border-2);
     padding: var(--space-1);
   }
+}
+
+.errorMessage {
+  color: var(--main-red);
+  font-size: var(--font-2);
+  font-weight: bold;
+  margin-top: var(--space-0);
 }

--- a/src/pages/SignUp/SignUp.module.css
+++ b/src/pages/SignUp/SignUp.module.css
@@ -13,7 +13,8 @@
 
 .container {
   /* height: 100vh; */
-  height: 100%;
+  /* height: 100%; */
+  height: calc(100vh - 77px);
   background-color: var(--white);
 
   display: flex;
@@ -80,4 +81,10 @@
       accent-color: var(--main-yellow);
     }
   }
+}
+
+.errorMessage{
+  color: var(--main-red);
+  font-weight: bold;
+  font-size: var(--font-2);
 }

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -1,38 +1,153 @@
-// interface Props
-
-import Header from "@/components/Header";
-import Navigation from "@/components/Navigation";
 import S from "./SignUp.module.css";
-import { useId } from "react";
-import SignUpImg from "@/assets/images/SignUp_neuro.svg"; // 회원가입 뉴로 이미지.
+import signUpImg from "@/assets/images/signUp_neuro.svg"; // 회원가입 뉴로 이미지.
 import Input from "@/components/Input";
 import SubmitButton from "@/components/SubmitButton";
+import useSignUp from "@/hooks/useSignUp";
+import { useState } from "react";
+import { insertProfile } from "@/utils/insertProfile";
+import { useNavigate } from "react-router-dom";
 
 function SignUp() {
+  const { signUp, loading, error } = useSignUp();
+  const navigate = useNavigate();
 
+  const [email, setEmail] = useState<string>("");
+  const [password, setPassword] = useState<string>("");
+  const [confirmPassword, setConfirmPassword] = useState<string>("");
+  const [nickname, setNickname] = useState<string>("");
+  const [gender, setGender] = useState<"male" | "female" | "other" | null>(
+    null
+  );
+  const [birth, setBirth] = useState<string | null>(null);
+  const [agreeToPrivacy, setAgreeToPrivacy] = useState<boolean>(false);
+  const [fieldErrors, setFieldErrors] = useState<{
+    email?: string;
+    password?: string;
+    confirmPassword?: string;
+    nickname?: string;
+    agreeToPrivacy?: string;
+    global?:string
+  }>({});
 
+  // 입력 필드 유효성 검사 함수.
+  const validateForm = () => {
+    const errors: typeof fieldErrors = {};
+
+    if (!email) errors.email = "이메일을 입력해 주세요.";
+    if (!password) errors.password = "비밀번호를 입력해 주세요.";
+    if (!confirmPassword)
+      errors.confirmPassword = "비밀번호 확인을 입력해 주세요.";
+    if (password && confirmPassword && password !== confirmPassword) {
+      errors.confirmPassword = "비밀번호가 일치하지 않습니다.";
+    }
+    if (!nickname) errors.nickname = "닉네임을 입력해 주세요.";
+    if (!agreeToPrivacy)
+      errors.agreeToPrivacy = "개인정보 수집에 동의해 주세요.";
+
+    return Object.keys(errors).length > 0 ? errors : null;
+  };
+
+  // 회원가입 제출 핸들러
+  const handelSubmitSignUp = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const errors = validateForm();
+    if (errors) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    setFieldErrors({}); // 기존 에러 초기화
+
+    const result = await signUp(email, password);
+
+    if (result) {
+      const userId = result.user?.id;
+      if (!userId) {
+        console.error("user ID가 존재하지 않습니다.");
+        setFieldErrors({
+          global: "회원가입은 되었지만 사용자 정보가 없습니다.",
+        });
+        return;
+      }
+
+      try {
+        await insertProfile({
+          id: userId,
+          nickname,
+          gender: gender ?? undefined,
+          birth: birth ?? undefined,
+        });
+
+        navigate("/");
+      } catch (profileErr) {
+        console.error("프로필 저장 실패:", profileErr);
+        setFieldErrors({
+          global: "회원가입은 되었지만 프로필 저장에 실패했습니다.",
+        });
+      }
+    } else {
+      setFieldErrors({ global: error ?? "회원가입 실패" });
+    }
+  };
 
   return (
-    <>
-      <Header title="회원가입" />
       <main className={S.container}>
         <h1 className={S["a11y-hidden"]}>회원가입</h1>
-        <img src={SignUpImg} alt="회원가입 안내 이미지" />
+        <img src={signUpImg} alt="회원가입 안내 이미지" />
 
-        <form>
-          <Input placeholder={"이메일을 입력해주세요. (필수)"} id={"id"} label={"ID"} />
-          
-          <Input placeholder={"비밀번호를 입력해주세요. (필수)"} id={"password"} label={"PW"} />
-          
-          <Input placeholder={"비밀번호를 다시 입력해 주세요. (필수)"} id={"confirmPassword"} label={"RE-PW"} />
-          
-          <Input placeholder={"닉네임을 입력해 주세요. (필수)"} id={"nickname"} label={"NICKNAME"} />
-          
+        <form onSubmit={handelSubmitSignUp}>
+          <Input
+            placeholder={"이메일을 입력해주세요. (필수)"}
+            id={"id"}
+            label={"ID"}
+            onChange={(e) => setEmail(e.target.value)}
+            error={fieldErrors.email}
+            disabled={loading}
+          />
+
+          <Input
+            placeholder={"비밀번호를 입력해주세요. (필수)"}
+            id={"password"}
+            label={"PW"}
+            onChange={(e) => setPassword(e.target.value)}
+            error={fieldErrors.password}
+            disabled={loading}
+          />
+
+          <Input
+            placeholder={"비밀번호를 다시 입력해 주세요. (필수)"}
+            id={"confirmPassword"}
+            label={"RE-PW"}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            error={fieldErrors.confirmPassword}
+            disabled={loading}
+          />
+
+          <Input
+            placeholder={"닉네임을 입력해 주세요. (필수)"}
+            id={"nickname"}
+            label={"NICKNAME"}
+            onChange={(e) => setNickname(e.target.value)}
+            error={fieldErrors.nickname}
+            disabled={loading}
+          />
+
           <fieldset className={S.optional}>
             <legend className={S["a11y-hidden"]}>선택 정보</legend>
             <div>
               <label htmlFor="gender">GENDER</label>
-              <select id='gender' name="gender">
+              <select
+                id="gender"
+                name="gender"
+                onChange={(e) => {
+                  const value = e.target.value;
+                  setGender(
+                    value === "" ? null : (value as "male" | "female" | "other")
+                  );
+                }}
+                disabled={loading}
+              >
                 <option value="">성별 선택</option>
                 <option value="male">남성</option>
                 <option value="female">여성</option>
@@ -42,21 +157,39 @@ function SignUp() {
 
             <div>
               <label htmlFor="birth">BIRTH</label>
-              <input type="date" id="birth" name="birth" />
+              <input
+                type="date"
+                id="birth"
+                name="birth"
+                onChange={(e) => setBirth(e.target.value)}
+                disabled={loading}
+              />
             </div>
           </fieldset>
 
           <fieldset className={S.agree}>
             <legend className={S["a11y-hidden"]}>약관 동의</legend>
-            <input type="checkbox" id="agree" name="privacy_agree" />
+            <input
+              type="checkbox"
+              id="agree"
+              name="privacy_agree"
+              onChange={(e) => setAgreeToPrivacy(e.target.checked)}
+              disabled={loading}
+            />
             <label htmlFor="agree">개인정보 동의하시겠습니까?</label>
           </fieldset>
-          
-          <SubmitButton label="회원가입"/>
+          {fieldErrors.agreeToPrivacy && (
+              <p className={S.errorMessage}>{fieldErrors.agreeToPrivacy}</p>
+            )}
+          {fieldErrors.global && <p className={S.errorMessage}>{fieldErrors.global}</p>}
+
+          <SubmitButton
+            label={loading ? "가입 중..." : "회원가입"}
+            type="submit"
+            disabled={loading}
+          />
         </form>
       </main>
-      <Navigation />
-    </>
   );
 }
 export default SignUp;

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -9,13 +9,8 @@ import Input from "@/components/Input";
 import SubmitButton from "@/components/SubmitButton";
 
 function SignUp() {
-  const id = useId();
-  const password = useId();
-  const confirmPassword = useId();
-  const nickname = useId();
-  const gender = useId();
-  const birth = useId();
-  const agree = useId();
+
+
 
   return (
     <>
@@ -25,19 +20,19 @@ function SignUp() {
         <img src={SignUpImg} alt="회원가입 안내 이미지" />
 
         <form>
-          <Input placeholder={"이메일을 입력해주세요. (필수)"} id={id} label={"ID"} />
+          <Input placeholder={"이메일을 입력해주세요. (필수)"} id={"id"} label={"ID"} />
           
-          <Input placeholder={"비밀번호를 입력해주세요. (필수)"} id={password} label={"PW"} />
+          <Input placeholder={"비밀번호를 입력해주세요. (필수)"} id={"password"} label={"PW"} />
           
-          <Input placeholder={"비밀번호를 다시 입력해 주세요. (필수)"} id={confirmPassword} label={"RE-PW"} />
+          <Input placeholder={"비밀번호를 다시 입력해 주세요. (필수)"} id={"confirmPassword"} label={"RE-PW"} />
           
-          <Input placeholder={"닉네임을 입력해 주세요. (필수)"} id={nickname} label={"NICKNAME"} />
+          <Input placeholder={"닉네임을 입력해 주세요. (필수)"} id={"nickname"} label={"NICKNAME"} />
           
           <fieldset className={S.optional}>
             <legend className={S["a11y-hidden"]}>선택 정보</legend>
             <div>
-              <label htmlFor={gender}>GENDER</label>
-              <select id={gender} name="gender">
+              <label htmlFor="gender">GENDER</label>
+              <select id='gender' name="gender">
                 <option value="">성별 선택</option>
                 <option value="male">남성</option>
                 <option value="female">여성</option>
@@ -46,15 +41,15 @@ function SignUp() {
             </div>
 
             <div>
-              <label htmlFor={birth}>BIRTH</label>
-              <input type="date" id={birth} name="birth" />
+              <label htmlFor="birth">BIRTH</label>
+              <input type="date" id="birth" name="birth" />
             </div>
           </fieldset>
 
           <fieldset className={S.agree}>
             <legend className={S["a11y-hidden"]}>약관 동의</legend>
-            <input type="checkbox" id={agree} name="privacy_agree" />
-            <label htmlFor={agree}>개인정보 동의하시겠습니까?</label>
+            <input type="checkbox" id="agree" name="privacy_agree" />
+            <label htmlFor="agree">개인정보 동의하시겠습니까?</label>
           </fieldset>
           
           <SubmitButton label="회원가입"/>

--- a/src/utils/insertProfile.ts
+++ b/src/utils/insertProfile.ts
@@ -1,0 +1,30 @@
+import { supabase } from "@/services/supabase";
+
+interface Payload {
+  id: string; // auth.users.id
+  nickname: string;
+  gender?: "male" | "female" | "other";
+  birth?: string;
+}
+
+
+export async function insertProfile({
+  id,
+  nickname,
+  gender,
+  birth,
+}: Payload) {
+  const payload: Record<string, any> = {
+    id,
+    nickname,
+  };
+  
+  if (gender !== undefined && gender !== null) payload.gender = gender;
+  if (birth !== undefined && birth !== null) payload.birth = birth;
+
+  const { data, error } = await supabase.from("profiles").insert([payload]);
+
+  if (error) throw error;
+  return data;
+}
+


### PR DESCRIPTION
## 📌 PR 요약

- 회원가입 페이지에 supabse auth 회원가입을 추가하였습니다.
- 회원가입 과정에서 발생하는 에러처리를 했습니다.
- 회원가입 과정에서 발생하는 로딩처리를 했습니다.
- 공용 컴포넌트인 `Input.tsx` , `SubmitButton.tsx`를 범용성 있게 수정했습니다.
: input 타입 추가
: 에처 발생시 디자인 처리
: 이벤트 콜백 처리

## ✅ 체크리스트

- [x] 해당 PR이 이슈와 연결되어 있다면, 이슈 번호를 명시했나요? (`Closes #번호`)
- [x] 기능이 정상 동작함을 확인했나요?
- [x] 팀원들과 사전에 공유된 내용인가요?
- [x] 코드 스타일 가이드(ESLint, Prettier 등)를 따랐나요?

## 📎 관련 이슈
- 아직 수정할 부분이 있습니다. 
: 라우팅 처리
: 페이지 높이 처리
- 해당 문제가 해결되면 이슈를 그때 닫도록 하겠습니다
Closes #️⃣

## 🧪 테스트 방법 (선택)

- supabase의 auth.user 테이블과 profiles 테이블을 빈 상태로 만들었습니다.
<img width="1039" height="295" alt="회원가입" src="https://github.com/user-attachments/assets/9a4ad732-e172-41de-baa4-df7a28fa54a7" />
<img width="1421" height="200" alt="회원가입2" src="https://github.com/user-attachments/assets/8acbcfc4-f3e4-422a-9509-62da337d2732" />

---

- 이후 회원가입을 시도 한 뒤의 결과입니다.
 
<img width="1100" height="203" alt="회원가입3" src="https://github.com/user-attachments/assets/75ea7f62-bd82-42ef-a056-dfacf1a8d5cb" />
<img width="1167" height="161" alt="회원가입 4" src="https://github.com/user-attachments/assets/49dd411c-c046-4227-b77c-4fed5d86badd" />

- 보시다시피 auth.user 테이블과 profiles 테이블에 유저 정보가 잘 나뉘어 저장되는 모습을 볼 수 있습니다.

---
- 다음과 같은 에러 처리를 했습니다
: 필수 입력값을 입력하지 않았을 때
: 개인정보 동의를 체크하지 않았을 때
: 비밀번호와 비밀번호 확인이 일치하지 않았을 때
: supabase 회원가입 시도중 에러가 발생했을 때

- 아래 사진은 필수 값 미 입력 에러 처리입니다. 
<img width="642" height="943" alt="에러" src="https://github.com/user-attachments/assets/9af76afa-1ffa-442d-aa74-1efa62fe92f1" />

---
- 다음은 로딩처리 입니다.
-  회원가입 처리는 외부 api와 통신하는 과정이므로 지연시간(로딩시간)이 필연적으로 생깁니다.
- 이때 입력 필드 값이 바뀌어선 안되며, 회원가입 버튼이 여러번 눌려 같은 중복된 요청을 보내도 안됩니다.
- 따라서 회원가입 버튼 클릭시 입력 필드와 제출버튼을 disabled하고, 제출 버튼에 `가입 중...`이라는 문구를 배치해 유저의 혼동을 방지하였습니다. 
- 해당 디자인은 임시로 진행했으며 추후에 디자인 변경의 여지가 있습니다.
<img width="639" height="941" alt="로딩중" src="https://github.com/user-attachments/assets/5929d169-378c-4c6d-b0b7-3e8119c28a71" />

