### PR TITLE
[feat] 이메일 대기 페이지 제작 / 회원가입 입력 필드 보완 (#44)

### DIFF
--- a/src/components/form/Input.tsx
+++ b/src/components/form/Input.tsx
@@ -1,26 +1,21 @@
 import S from "../styles/form.module.css";
 
 interface Props {
+  type?:string
   placeholder: string;
   label: string;
   id: string;
-  onChange?: (
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
-  ) => void;
+  onChange?: (e:React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
   error?: string;
   disabled?: boolean;
 }
 
-function Input({ placeholder, id, label, onChange, error, disabled }: Props) {
+function Input({ type, placeholder, id, label, onChange, error, disabled }: Props) {
+  
   return (
     <label htmlFor={id} className={S.inputContainer}>
       <p>{label}</p>
-      <input
-        type="text"
-        placeholder={placeholder}
-        onChange={onChange}
-        disabled={disabled}
-      />
+      <input type={type} placeholder={placeholder} onChange={onChange} disabled={disabled}/>
       {error && <p className={S.errorMessage}>{error}</p>}
     </label>
   );

--- a/src/components/form/SubmitButton.tsx
+++ b/src/components/form/SubmitButton.tsx
@@ -1,16 +1,10 @@
 import S from "../styles/form.module.css";
-
 interface Props {
   label: string;
   type?: "button" | "submit" | "reset";
   disabled?: boolean;
 }
-
 function SubmitButton({ label, type = "button", disabled = false }: Props) {
-  return (
-    <button type={type} className={S.submitButton} disabled={disabled}>
-      {label}
-    </button>
-  );
+  return <button type={type} className={S.submitButton} disabled={disabled}>{label}</button>;
 }
 export default SubmitButton;

--- a/src/components/styles/form.module.css
+++ b/src/components/styles/form.module.css
@@ -19,10 +19,18 @@
   }
   input {
     width: 328px;
-    border: 1px solid var(--light-gray);
+    border: 2px solid var(--light-gray);
     border-radius: var(--border-2);
     padding: var(--space-1);
+
+    &:focus {
+      outline: none;
+      border-width: 2px;
+      border-color: var(--main-blue);
+      background-color: #fffbe6;
+    }
   }
+
 }
 
 .errorMessage {

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -3,7 +3,7 @@ import Footer from "./components/Footer";
 import RankingModal from "@/components/modals/Ranking/RankingModal";
 import { useEffect, useState } from "react";
 import { rankingData } from "@/components/modals/Ranking/RankData";
-import SignUp from "../SignUp/SignUp";
+import { AppLink } from "@/router/AppLink";
 
 function HomePage() {
   const [isOpen, setIsOpen] = useState(false);
@@ -11,6 +11,7 @@ function HomePage() {
     if (isOpen) setIsOpen(false);
     else setIsOpen(true);
   };
+
 
   useEffect(() => {}, [isOpen]);
   return (
@@ -30,7 +31,10 @@ function HomePage() {
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
       />
-      <SignUp />
+      
+      <AppLink to={"sign-up"} variant={"page"}>
+        <button type="button">회원가입 입니디~</button>
+      </AppLink>
 
       <Footer />
     </>

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -3,6 +3,7 @@ import Footer from "./components/Footer";
 import RankingModal from "@/components/modals/Ranking/RankingModal";
 import { useEffect, useState } from "react";
 import { rankingData } from "@/components/modals/Ranking/RankData";
+import SignUp from "../SignUp/SignUp";
 
 function HomePage() {
   const [isOpen, setIsOpen] = useState(false);
@@ -29,6 +30,7 @@ function HomePage() {
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
       />
+      <SignUp />
 
       <Footer />
     </>

--- a/src/pages/SignUp/PendingEmail.module.css
+++ b/src/pages/SignUp/PendingEmail.module.css
@@ -1,0 +1,24 @@
+
+.container{
+  height: calc(100vh - 77px);
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+
+  background-color: var(--main-blue);
+
+  p{
+    font-weight: bold;
+    font-size: var(--font-5);
+  }
+
+  button{
+    background-color: var(--main-yellow);
+  }
+}
+
+
+

--- a/src/pages/SignUp/PendingEmail.tsx
+++ b/src/pages/SignUp/PendingEmail.tsx
@@ -1,0 +1,37 @@
+import { supabase } from "@/services/supabase"
+import { useEffect } from "react"
+import { useNavigate } from "react-router-dom";
+import S from "./PendingEmail.module.css";
+
+
+function PendingEmail() {
+   const navigate = useNavigate();
+
+
+  useEffect(() => {
+    const { data: listener } = supabase.auth.onAuthStateChange(
+      async (event, session) => {
+        if (event === "SIGNED_IN" && session?.user?.email_confirmed_at) {
+          navigate("/"); // 인증 완료 → 홈 이동
+        }
+      }
+    );
+
+    return () => {
+      listener.subscription.unsubscribe();
+    };
+
+  },[])
+
+
+  return (
+      <main className={S.container}>
+        <p>메일을 확인해 주세요!</p>
+        <p>당신의 뇌가 깨어날 준비를 하고 있어요!</p>
+        <img src="#" alt="이메일 대기 화면 이미지" />
+        <p>방금 전송된 인증 메일의 버튼을 눌러 뇌하수체의 문을 여세요♥️</p>
+        <button type="button">새로고침</button>
+      </main>
+  )
+}
+export default PendingEmail

--- a/src/pages/SignUp/SignUp.module.css
+++ b/src/pages/SignUp/SignUp.module.css
@@ -47,21 +47,35 @@
 
       input{
         border-style: solid;
-        border-width: 1px;
+        border-width: 2px;
         border-color: var(--light-gray);
         padding: var(--space-1);
         border-radius: var(--border-2);
         color: var(--dark-gray);
+        outline: none;
+
+        &:focus {
+          border-width: 2px;
+          border-color: var(--main-blue);
+          background-color: #fffbe6;
+        }
       }
 
       select{
         /* appearance: none; 아래 화살표 아이콘 */
         border-style: solid;
-        border-width: 1px;
+        border-width: 2px;
         border-color: var(--light-gray);
         padding: var(--space-1);
         border-radius: var(--border-2);
         color: var(--dark-gray);
+        outline: none;
+
+        &:focus {
+          border-width: 2px;
+          border-color: var(--main-blue);
+          background-color: #fffbe6;
+        }
       }
       option{
         border-radius: var(--border-2);

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -26,7 +26,7 @@ function SignUp() {
     confirmPassword?: string;
     nickname?: string;
     agreeToPrivacy?: string;
-    global?: string;
+    global?:string
   }>({});
 
   // 입력 필드 유효성 검사 함수.
@@ -72,14 +72,14 @@ function SignUp() {
       }
 
       try {
-        await insertProfile({
+        await insertProfile({ //db에 넣기
           id: userId,
           nickname,
           gender: gender ?? undefined,
           birth: birth ?? undefined,
         });
 
-        navigate("/");
+        navigate("/pending-email");
       } catch (profileErr) {
         console.error("프로필 저장 실패:", profileErr);
         setFieldErrors({
@@ -92,106 +92,107 @@ function SignUp() {
   };
 
   return (
-    <main className={S.container}>
-      <h1 className={S["a11y-hidden"]}>회원가입</h1>
-      <img src={signUpImg} alt="회원가입 안내 이미지" />
+      <main className={S.container}>
+        <h1 className={S["a11y-hidden"]}>회원가입</h1>
+        <img src={signUpImg} alt="회원가입 안내 이미지" />
 
-      <form onSubmit={handelSubmitSignUp}>
-        <Input
-          placeholder={"이메일을 입력해주세요. (필수)"}
-          id={"id"}
-          label={"ID"}
-          onChange={(e) => setEmail(e.target.value)}
-          error={fieldErrors.email}
-          disabled={loading}
-        />
-
-        <Input
-          placeholder={"비밀번호를 입력해주세요. (필수)"}
-          id={"password"}
-          label={"PW"}
-          onChange={(e) => setPassword(e.target.value)}
-          error={fieldErrors.password}
-          disabled={loading}
-        />
-
-        <Input
-          placeholder={"비밀번호를 다시 입력해 주세요. (필수)"}
-          id={"confirmPassword"}
-          label={"RE-PW"}
-          onChange={(e) => setConfirmPassword(e.target.value)}
-          error={fieldErrors.confirmPassword}
-          disabled={loading}
-        />
-
-        <Input
-          placeholder={"닉네임을 입력해 주세요. (필수)"}
-          id={"nickname"}
-          label={"NICKNAME"}
-          onChange={(e) => setNickname(e.target.value)}
-          error={fieldErrors.nickname}
-          disabled={loading}
-        />
-
-        <fieldset className={S.optional}>
-          <legend className={S["a11y-hidden"]}>선택 정보</legend>
-          <div>
-            <label htmlFor="gender">GENDER</label>
-            <select
-              id="gender"
-              name="gender"
-              onChange={(e) => {
-                const value = e.target.value;
-                setGender(
-                  value === "" ? null : (value as "male" | "female" | "other")
-                );
-              }}
-              disabled={loading}
-            >
-              <option value="">성별 선택</option>
-              <option value="male">남성</option>
-              <option value="female">여성</option>
-              <option value="other">기타</option>
-            </select>
-          </div>
-
-          <div>
-            <label htmlFor="birth">BIRTH</label>
-            <input
-              type="date"
-              id="birth"
-              name="birth"
-              onChange={(e) => setBirth(e.target.value)}
-              disabled={loading}
-            />
-          </div>
-        </fieldset>
-
-        <fieldset className={S.agree}>
-          <legend className={S["a11y-hidden"]}>약관 동의</legend>
-          <input
-            type="checkbox"
-            id="agree"
-            name="privacy_agree"
-            onChange={(e) => setAgreeToPrivacy(e.target.checked)}
+        <form onSubmit={handelSubmitSignUp}>
+          <Input
+            type={"email"}
+            placeholder={"이메일을 입력해주세요. (필수)"}
+            id={"id"}
+            label={"ID"}
+            onChange={(e) => setEmail(e.target.value)}
+            error={fieldErrors.email}
             disabled={loading}
           />
-          <label htmlFor="agree">개인정보 동의하시겠습니까?</label>
-        </fieldset>
-        {fieldErrors.agreeToPrivacy && (
-          <p className={S.errorMessage}>{fieldErrors.agreeToPrivacy}</p>
-        )}
-        {fieldErrors.global && (
-          <p className={S.errorMessage}>{fieldErrors.global}</p>
-        )}
 
-        <SubmitButton
-          label={loading ? "가입 중..." : "회원가입"}
-          type="submit"
-          disabled={loading}
-        />
-      </form>
-    </main>
+          <Input
+            type={"password"}
+            placeholder={"비밀번호를 입력해주세요. (필수)"}
+            id={"password"}
+            label={"PW"}
+            onChange={(e) => setPassword(e.target.value)}
+            error={fieldErrors.password}
+            disabled={loading}
+          />
+
+          <Input
+            type={"password"}
+            placeholder={"비밀번호를 다시 입력해 주세요. (필수)"}
+            id={"confirmPassword"}
+            label={"RE-PW"}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            error={fieldErrors.confirmPassword}
+            disabled={loading}
+          />
+
+          <Input
+            placeholder={"닉네임을 입력해 주세요. (필수)"}
+            id={"nickname"}
+            label={"NICKNAME"}
+            onChange={(e) => setNickname(e.target.value)}
+            error={fieldErrors.nickname}
+            disabled={loading}
+          />
+
+          <fieldset className={S.optional}>
+            <legend className={S["a11y-hidden"]}>선택 정보</legend>
+            <div>
+              <label htmlFor="gender">GENDER</label>
+              <select
+                id="gender"
+                name="gender"
+                onChange={(e) => {
+                  const value = e.target.value;
+                  setGender(
+                    value === "" ? null : (value as "male" | "female" | "other")
+                  );
+                }}
+                disabled={loading}
+              >
+                <option value="">성별 선택</option>
+                <option value="male">남성</option>
+                <option value="female">여성</option>
+                <option value="other">기타</option>
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="birth">BIRTH</label>
+              <input
+                type="date"
+                id="birth"
+                name="birth"
+                onChange={(e) => setBirth(e.target.value)}
+                disabled={loading}
+              />
+            </div>
+          </fieldset>
+
+          <fieldset className={S.agree}>
+            <legend className={S["a11y-hidden"]}>약관 동의</legend>
+            <input
+              type="checkbox"
+              id="agree"
+              name="privacy_agree"
+              onChange={(e) => setAgreeToPrivacy(e.target.checked)}
+              disabled={loading}
+            />
+            <label htmlFor="agree">개인정보 동의하시겠습니까?</label>
+          </fieldset>
+          {fieldErrors.agreeToPrivacy && (
+              <p className={S.errorMessage}>{fieldErrors.agreeToPrivacy}</p>
+            )}
+          {fieldErrors.global && <p className={S.errorMessage}>{fieldErrors.global}</p>}
+
+          <SubmitButton
+            label={loading ? "가입 중..." : "회원가입"}
+            type="submit"
+            disabled={loading}
+          />
+        </form>
+      </main>
   );
 }
 export default SignUp;

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -5,6 +5,7 @@ import NotFoundPage from "@/pages/NotFound/NotFoundPage";
 import NoticePage from "@/pages/Notice/NoticePage";
 import QnaPage from "@/pages/Qna/QnaPage";
 import PendingEmail from "@/pages/SignUp/PendingEmail";
+import SignUp from "@/pages/SignUp/SignUp";
 import { createBrowserRouter } from "react-router-dom";
 
 const routes = createBrowserRouter([
@@ -26,8 +27,9 @@ const routes = createBrowserRouter([
         element: <NoticePage />,
       },
       { handle: { title: "고객문의" }, path: "/qna", element: <QnaPage /> },
+      { handle: { title: "이메일 대기" }, path: "pending-email", element: <PendingEmail /> },
+      { handle: { title: "회원가입" }, path: "sign-up", element: <SignUp /> },
       { handle: { title: "ERROR" }, path: "*", element: <NotFoundPage /> },
-      { handle: { title: "이메일 대기" }, path: "/pendding-email", element: <PendingEmail /> },
     ],
   },
 ]);

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -4,6 +4,7 @@ import HomePage from "@/pages/Home/HomePage";
 import NotFoundPage from "@/pages/NotFound/NotFoundPage";
 import NoticePage from "@/pages/Notice/NoticePage";
 import QnaPage from "@/pages/Qna/QnaPage";
+import PendingEmail from "@/pages/SignUp/PendingEmail";
 import { createBrowserRouter } from "react-router-dom";
 
 const routes = createBrowserRouter([
@@ -26,6 +27,7 @@ const routes = createBrowserRouter([
       },
       { handle: { title: "고객문의" }, path: "/qna", element: <QnaPage /> },
       { handle: { title: "ERROR" }, path: "*", element: <NotFoundPage /> },
+      { handle: { title: "이메일 대기" }, path: "/pendding-email", element: <PendingEmail /> },
     ],
   },
 ]);


### PR DESCRIPTION
## 📌 PR 요약
- 이메일 대기 페이지를 만들었습니다. (디자인은 추후에..)
- SMTP 템플릿을 제작했습니다.
- 회원가입 입력 필드의 UX를 보완했습니다.
: 기존 Input.tsx에 type 프롭스를 추가해 비밀번호는 ...으로 나오도록 변경
: 기존 Input.tsx에 type 프롭스를 추가해 이메일은 브라우저 단에서 한번 더 이메일 형식을 보장해주는 로직으로 변경했습니다.

## ✅ 체크리스트

- [ ] 해당 PR이 이슈와 연결되어 있다면, 이슈 번호를 명시했나요? (`Closes #번호`)
- [x] 기능이 정상 동작함을 확인했나요?
- [x] 팀원들과 사전에 공유된 내용인가요?
- [x] 코드 스타일 가이드(ESLint, Prettier 등)를 따랐나요?

## 📎 관련 이슈

Closes #44 

## 🧪 테스트 방법 (선택)

- 회원가입 입력 필드 보완 사항입니다.
<img width="559" height="303" alt="회원가입 필드 보완" src="https://github.com/user-attachments/assets/e46dc799-7300-4791-b58a-7dfe50728988" />

---

- 이메일 대기 페이지 입니다.
<img width="637" height="942" alt="팬딩 페이지" src="https://github.com/user-attachments/assets/149b553a-6b40-43b5-8a9d-f4a051633137" />


---

- SMTP 이메일 템플릿입니다.
<img width="763" height="688" alt="SMTP" src="https://github.com/user-attachments/assets/aa391fe3-a728-448a-831f-453363e3faf3" />

