### PR TITLE
[feat] 로그인 페이지 완성 (#69)

### DIFF
--- a/src/components/form/Input.tsx
+++ b/src/components/form/Input.tsx
@@ -16,7 +16,9 @@ function Input({ type, placeholder, id, label, onChange, error, disabled }: Prop
     <label htmlFor={id} className={S.inputContainer}>
       <p>{label}</p>
       <input type={type} placeholder={placeholder} onChange={onChange} disabled={disabled}/>
-      {error && <p className={S.errorMessage}>{error}</p>}
+      <p className={S.errorMessage}>
+        {error ? error : "\u00A0" /* 공백 유니코드로 줄 유지 */}
+      </p>
     </label>
   );
 }

--- a/src/components/styles/form.module.css
+++ b/src/components/styles/form.module.css
@@ -38,4 +38,5 @@
   font-size: var(--font-2);
   font-weight: bold;
   margin-top: var(--space-0);
+  user-select: none;
 }

--- a/src/pages/Login/Login.module.css
+++ b/src/pages/Login/Login.module.css
@@ -72,3 +72,12 @@
   pointer-events: none;
   user-select: none;
 }
+
+.globalErrorMessage {
+  color: var(--main-red);
+  font-size: var(--font-2);
+  font-weight: bold;
+  text-align: center;
+  user-select: none;
+  margin-bottom: 0.5rem;
+}

--- a/src/pages/Login/Login.module.css
+++ b/src/pages/Login/Login.module.css
@@ -34,7 +34,7 @@
   .findActions{
     display: flex;
     flex-direction: column;
-    gap: 5rem;
+    gap: 6rem;
 
     .actionWrap{
       display: flex;

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -101,10 +101,12 @@ function Login() {
           />
         </fieldset>
 
-        {fieldErrors.global && (
-          <p className={S.errorMessage}>{fieldErrors.global}</p>
-        )}
-        <SubmitButton label="로그인" type="submit" />
+        <div className="btnWrap">
+          {fieldErrors.global && (
+            <p className={S.errorMessage}>{fieldErrors.global}</p>
+          )}
+          <SubmitButton label="로그인" type="submit" />
+        </div>
       </form>
 
       <div className={S.findActions}>

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -5,24 +5,80 @@ import SubmitButton from "@/components/form/SubmitButton";
 import { useState } from "react";
 import useLogin from "@/hooks/useLogin";
 import { AppLink } from "@/router/AppLink";
+import { useNavigate } from "react-router-dom";
 
 function Login() {
+  const navigate = useNavigate();
   const { login, loading, error } = useLogin();
 
   const [id, setId] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [fieldErrors, setFieldErrors] = useState<{
-    email?: string;
+    id?: string;
     password?: string;
     global?: string;
   }>({});
+
+  const validateForm = () => {
+    const errors: typeof fieldErrors = {};
+
+    if (!id) errors.id = "이메일을 입력해주세요.";
+    if (!id) errors.password = "비밀번호를 입력해주세요.";
+
+    return Object.keys(errors).length > 0 ? errors : null; // 에러가 하나라도 있으면 errors 객체 반환.
+  };
+
+  const handleSumitLogin = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const errors = validateForm();
+    if (errors) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    setFieldErrors({});
+
+    try {
+      const result = await login(id, password);
+
+      if (result) {
+        const user = result.user;
+        const session = result.session;
+
+        if (!user || !session) {
+          // 로그인 성공은 했는데 data가 비어있는 경우. (거의 일어나지 않음)
+          setFieldErrors({
+            global: "로그인에 실패했습니다. 다시 시도해주세요.",
+          });
+          return;
+        }
+
+        // ✅ 로그인 성공 처리
+        console.log("로그인 성공:", user);
+        navigate("/") // 홈 화면으로 라우팅.
+      }
+    } catch (err: unknown) {
+      let message = "로그인 중 알 수 없는 오류가 발생했습니다.";
+
+      if (err instanceof Error) {
+        if (err.message === "Invalid login credentials") {
+          message = "이메일 또는 비밀번호가 올바르지 않습니다.";
+        } else {
+          message = err.message; // 기타 메시지 직접 표시
+        }
+      }
+
+      setFieldErrors({ global: message });
+    }
+  };
 
   return (
     <main className={S.container}>
       <h1 className={S["a11y-hidden"]}>로그인</h1>
       <img src={loginImg} alt="로그인 마스코트 이미지" />
 
-      <form>
+      <form onSubmit={handleSumitLogin}>
         <fieldset>
           <Input
             type={"email"}
@@ -30,7 +86,7 @@ function Login() {
             id={"id"}
             label={"ID"}
             onChange={(e) => setId(e.target.value)}
-            error={fieldErrors.email}
+            error={fieldErrors.id}
             disabled={loading}
           />
 
@@ -40,7 +96,7 @@ function Login() {
             id={"password"}
             label={"PW"}
             onChange={(e) => setPassword(e.target.value)}
-            error={fieldErrors.email}
+            error={fieldErrors.password}
             disabled={loading}
           />
         </fieldset>
@@ -64,7 +120,9 @@ function Login() {
 
         <div className={S.signUpWrap}>
           <p>아직 회원이 아니신가요?</p>
-          <AppLink to={"/sign-up"} variant={"page"}>회원가입</AppLink>
+          <AppLink to={"/sign-up"} variant={"page"}>
+            회원가입
+          </AppLink>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## 📌 PR 요약

- 로그인 페이지를 구현했습니다.
- ui가 깨지지 않는 에러처리를 구현했습니다.
- supabase 로그인을 통해 자동 세션 발급 됩니다.

## ✅ 체크리스트

- [x] 해당 PR이 이슈와 연결되어 있다면, 이슈 번호를 명시했나요? (`Closes #번호`)
- [x] 기능이 정상 동작함을 확인했나요?
- [x] 팀원들과 사전에 공유된 내용인가요?
- [x] 코드 스타일 가이드(ESLint, Prettier 등)를 따랐나요?

## 📎 관련 이슈

Closes #69 

## 🧪 테스트 방법 (선택)

- 로그인 에러처리입니다.
<img width="635" height="939" alt="로그인밸리데이션" src="https://github.com/user-attachments/assets/d4a70146-78f1-4822-9bc9-2bedfc492a3f" />


---

- 로그인 전입니다. 세션이 현재 없는 상태입니다.
<img width="807" height="658" alt="로그인 전" src="https://github.com/user-attachments/assets/6cad1201-bc80-43cf-8ca4-b7ac9133d840" />


---

- 로그인 이후 입니다. 홈으로 라우팅도 잘되며, 세션도 자동 발급됩니다.
<img width="832" height="563" alt="로그인 후" src="https://github.com/user-attachments/assets/7dd60691-d21f-4845-860f-aeaf8a3f1892" />

