### PR TITLE
[fix] PlayPage 공통 컴포넌트에 props 추가(#null)

### DIFF
--- a/src/pages/Games/LetterColor/LetterColorPlay.tsx
+++ b/src/pages/Games/LetterColor/LetterColorPlay.tsx
@@ -1,11 +1,24 @@
-import type { Play } from "../components/PlayPage";
+import { useEffect } from "react";
+import type { State } from "../components/PlayPage";
 import S from "./LetterColorPlay.module.css";
 
 interface Props {
-  state: Play;
+  state: State;
   onFinish: () => void;
+  handleScore: (score: number) => void;
+  handleGameOverMessage: (message: string) => void;
 }
-function LetterColorPlaying({ state, onFinish }: Props) {
+function LetterColorPlaying({
+  state,
+  onFinish,
+  handleScore,
+  handleGameOverMessage,
+}: Props) {
+  useEffect(() => {
+    handleScore(2319845);
+    handleGameOverMessage("타임오버!");
+  }, []);
+
   return (
     <div className={S.container}>
       {state}

--- a/src/pages/Games/LetterColor/LetterColorPlay.tsx
+++ b/src/pages/Games/LetterColor/LetterColorPlay.tsx
@@ -5,18 +5,18 @@ import S from "./LetterColorPlay.module.css";
 interface Props {
   state: State;
   onFinish: () => void;
-  handleScore: (score: number) => void;
-  handleGameOverMessage: (message: string) => void;
+  onScoreCalculated: (score: number) => void;
+  onGameOver: (message: string) => void;
 }
 function LetterColorPlaying({
   state,
   onFinish,
-  handleScore,
-  handleGameOverMessage,
+  onScoreCalculated,
+  onGameOver,
 }: Props) {
   useEffect(() => {
-    handleScore(2319845);
-    handleGameOverMessage("타임오버!");
+    onScoreCalculated(2319845);
+    onGameOver("타임오버!");
   }, []);
 
   return (

--- a/src/pages/Games/LetterColor/LetterColorPlayPage.tsx
+++ b/src/pages/Games/LetterColor/LetterColorPlayPage.tsx
@@ -10,12 +10,12 @@ function LetterColorGamePage() {
       boldDescription={"중요한건 색깔!"}
       description={"주어진 글자의 색깔을 입력해 주세요."}
     >
-      {(state, onFinish, getScore, getGameOverMessage) => (
+      {(state, onFinish, onScoreCalculated, onGameOver) => (
         <LetterColorPlay
           state={state}
           onFinish={onFinish}
-          handleScore={getScore}
-          handleGameOverMessage={getGameOverMessage}
+          onScoreCalculated={onScoreCalculated}
+          onGameOver={onGameOver}
         />
       )}
     </PlayPage>

--- a/src/pages/Games/LetterColor/LetterColorPlayPage.tsx
+++ b/src/pages/Games/LetterColor/LetterColorPlayPage.tsx
@@ -1,11 +1,22 @@
 import PlayPage from "../components/PlayPage";
 import LetterColorPlay from "./LetterColorPlay";
+import letterColor from "@/assets/images/game/letterColor_game.svg";
 
 function LetterColorGamePage() {
   return (
-    <PlayPage>
-      {(state, onFinish) => (
-        <LetterColorPlay state={state} onFinish={onFinish} />
+    <PlayPage
+      gameImg={letterColor}
+      imgAlt={"글자 색 맞추기 게임"}
+      boldDescription={"중요한건 색깔!"}
+      description={"주어진 글자의 색깔을 입력해 주세요."}
+    >
+      {(state, onFinish, getScore, getGameOverMessage) => (
+        <LetterColorPlay
+          state={state}
+          onFinish={onFinish}
+          handleScore={getScore}
+          handleGameOverMessage={getGameOverMessage}
+        />
       )}
     </PlayPage>
   );

--- a/src/pages/Games/components/FinishGame.tsx
+++ b/src/pages/Games/components/FinishGame.tsx
@@ -1,19 +1,17 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import S from "./styles/FinishGame.module.css";
 import cryingNeuro from "@/assets/images/game/crying_neuro.svg";
-import type { Play } from "./PlayPage";
+import type { State } from "./PlayPage";
 
 interface Props {
-  state: Play;
+  state: State;
   onShowResult: () => void;
+  gameOverMessage: string | null;
 }
 
-function FinishGame({ state, onShowResult }: Props) {
-  const [result, setResult] = useState<string | null>(null);
-
+function FinishGame({ state, onShowResult, gameOverMessage }: Props) {
   useEffect(() => {
     if (state !== "finish") return;
-    setResult("즉탈메세지 로직 만들어야해요...");
     setTimeout(() => {
       onShowResult();
     }, 3000);
@@ -24,7 +22,9 @@ function FinishGame({ state, onShowResult }: Props) {
       <div className={S.inner}>
         <div className={S.gameOver}>GAME OVER</div>
         <img src={cryingNeuro} alt="게임 오버" />
-        <div className={S.box}>{result}</div>
+        <div className={S.box}>
+          {gameOverMessage ? gameOverMessage : "로딩중..."}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Games/components/GameResult.tsx
+++ b/src/pages/Games/components/GameResult.tsx
@@ -1,24 +1,23 @@
-import { useState } from "react";
 import S from "./styles/GameResult.module.css";
 import resultNeuro from "@/assets/images/game/result_neuro.svg";
 
 interface Props {
-  onStart: () => void;
+  onRestart: () => void;
   onWait: () => void;
+  score: number | null;
 }
 
-function GameResult({ onStart, onWait }: Props) {
-  const [score] = useState(23331);
+function GameResult({ onRestart, onWait, score }: Props) {
   return (
     <div className={S.container}>
       <div className={S.inner}>
         <div className={S.score}>
           <div>당신의 점수</div>
-          <div className={S.value}>{score}점</div>
+          <div className={S.value}>{score ? `${score}점` : "계산중..."}</div>
         </div>
         <img src={resultNeuro} alt="게임 결과" />
         <div className={S.buttonContainer}>
-          <button type="button" onClick={onStart}>
+          <button type="button" onClick={onRestart}>
             다시 시작!
           </button>
           <button className={S.quit} type="button" onClick={onWait}>

--- a/src/pages/Games/components/PlayPage.tsx
+++ b/src/pages/Games/components/PlayPage.tsx
@@ -1,44 +1,93 @@
 import { useState } from "react";
-import letterColor from "@/assets/images/game/letterColor_game.svg";
 import StartGame from "./StartGame";
 import StartCountdown from "./StartCountdown";
 import FinishGame from "./FinishGame";
 import GameResult from "./GameResult";
 
-export type Play = "waiting" | "starting" | "playing" | "finish" | "result";
+export type State = "waiting" | "starting" | "playing" | "finish" | "result";
 
 interface Props {
-  children: (state: Play, finishGame: () => void) => React.ReactNode;
+  children: (
+    state: State,
+    finishGame: () => void,
+    getScore: (score: number) => void,
+    getGameOverMessage: (message: string) => void
+  ) => React.ReactNode;
+  gameImg: string;
+  imgAlt: string;
+  boldDescription: string;
+  description: string;
 }
 
-function PlayPage({ children }: Props) {
-  const [play, setPlay] = useState<Play>("waiting");
+function PlayPage({
+  children,
+  gameImg,
+  imgAlt,
+  boldDescription,
+  description,
+}: Props) {
+  const [gameState, setGameState] = useState<State>("waiting");
+  const [score, setScore] = useState<number | null>(null);
+  const [gameOverMessage, setGameOverMessage] = useState<string | null>(null);
+
+  //결과 보고 게임 점수랑 메세지 reset 필요 이건 GameResult 컴포넌트에 onReset={()=>setScore(null)} 이거 쓰면 될듯
+  // 게임 점수 로딩중에 조건문 필요 {(score&&gameOverMessage)|<FinishGame/>:"로딩중"} 이런느낌..
 
   const finishGame = () => {
-    setPlay("finish");
+    setGameState("finish");
   };
+
+  const getScore = (score: number) => {
+    setScore(score);
+  };
+
+  const getGameOverMessage = (message: string) => {
+    setGameOverMessage(message);
+  };
+
+  const handleReStart = () => {
+    setGameState("starting");
+    setScore(null);
+    setGameOverMessage(null);
+  };
+
+  const handleReWait = () => {
+    setGameState("waiting");
+    setScore(null);
+    setGameOverMessage(null);
+  };
+
   return (
     <>
-      {play === "waiting" && (
+      {gameState === "waiting" && (
         <StartGame
-          img={letterColor}
-          alt={"글자 색 맞추기 게임"}
-          boldText={"중요한건 색깔!"}
-          text={"주어진 글자의 색깔을 입력해 주세요."}
-          onStart={() => setPlay("starting")}
+          img={gameImg}
+          alt={imgAlt}
+          boldText={boldDescription}
+          text={description}
+          onStart={() => setGameState("starting")}
         />
       )}
-      {play === "starting" && (
-        <StartCountdown state={play} onCount={() => setPlay("playing")} />
+      {gameState === "starting" && (
+        <StartCountdown
+          state={gameState}
+          onCount={() => setGameState("playing")}
+        />
       )}
-      {play !== "waiting" && children(play, finishGame)}
-      {play === "finish" && (
-        <FinishGame state={play} onShowResult={() => setPlay("result")} />
+      {gameState !== "waiting" &&
+        children(gameState, finishGame, getScore, getGameOverMessage)}
+      {gameState === "finish" && (
+        <FinishGame
+          state={gameState}
+          onShowResult={() => setGameState("result")}
+          gameOverMessage={gameOverMessage}
+        />
       )}
-      {play === "result" && (
+      {gameState === "result" && (
         <GameResult
-          onStart={() => setPlay("starting")}
-          onWait={() => setPlay("waiting")}
+          onRestart={handleReStart}
+          onWait={handleReWait}
+          score={score}
         />
       )}
     </>

--- a/src/pages/Games/components/PlayPage.tsx
+++ b/src/pages/Games/components/PlayPage.tsx
@@ -10,8 +10,8 @@ interface Props {
   children: (
     state: State,
     finishGame: () => void,
-    getScore: (score: number) => void,
-    getGameOverMessage: (message: string) => void
+    onScoreCalculated: (score: number) => void,
+    onGameOver: (message: string) => void
   ) => React.ReactNode;
   gameImg: string;
   imgAlt: string;
@@ -37,11 +37,11 @@ function PlayPage({
     setGameState("finish");
   };
 
-  const getScore = (score: number) => {
+  const onScoreCalculated = (score: number) => {
     setScore(score);
   };
 
-  const getGameOverMessage = (message: string) => {
+  const onGameOver = (message: string) => {
     setGameOverMessage(message);
   };
 
@@ -75,7 +75,7 @@ function PlayPage({
         />
       )}
       {gameState !== "waiting" &&
-        children(gameState, finishGame, getScore, getGameOverMessage)}
+        children(gameState, finishGame, onScoreCalculated, onGameOver)}
       {gameState === "finish" && (
         <FinishGame
           state={gameState}

--- a/src/pages/Games/components/StartCountdown.tsx
+++ b/src/pages/Games/components/StartCountdown.tsx
@@ -3,10 +3,10 @@ import S from "./styles/StartCountdown.module.css";
 import counter1 from "@/assets/icons/counter1.svg";
 import counter2 from "@/assets/icons/counter2.svg";
 import counter3 from "@/assets/icons/counter3.svg";
-import type { Play } from "./PlayPage";
+import type { State } from "./PlayPage";
 
 interface Props {
-  state: Play;
+  state: State;
   onCount: () => void;
 }
 


### PR DESCRIPTION
## 📌 PR 요약

- 무엇을 구현하거나 수정했는지 요약해주세요.
- issue에는 안올렸지만 정주님이 PlayPage에 게임을 교체할 수 있는 props가 없다고 해서 추가했습니다.
- score, gameOverMseeage 상태도 추가해둔 상태입니다.
```
    <PlayPage
      gameImg={letterColor}
      imgAlt={"글자 색 맞추기 게임"}
      boldDescription={"중요한건 색깔!"}
      description={"주어진 글자의 색깔을 입력해 주세요."}
    >
      {(state, onFinish, onScoreCalculated, onGameOver) => (
        <LetterColorPlay
          state={state}
          onFinish={onFinish}
          onScoreCalculated={onScoreCalculated}
          onGameOver={onGameOver}
        />
      )}
    </PlayPage>
```
게임 로직 안에서 onScoreCalculated({현재점수}), onGameOver({게임오버 메세지}) 쓰시면 결과창에 전달됩니다.

## ✅ 체크리스트

- [ ] 해당 PR이 이슈와 연결되어 있다면, 이슈 번호를 명시했나요? (`Closes #번호`)
- [x] 기능이 정상 동작함을 확인했나요?
- [x] 팀원들과 사전에 공유된 내용인가요?
- [x] 코드 스타일 가이드(ESLint, Prettier 등)를 따랐나요?

## 📎 관련 이슈

Closes 

## 🧪 테스트 방법 (선택)

직접 테스트해본 방법이 있다면 설명해주세요.
