### PR TITLE
[feat] 세션 여부에 따른 마이페이지 라우팅 분기 처리 (#87)

### DIFF
--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -2,9 +2,23 @@ import { useState } from "react";
 import S from "../styles/fixedLayout.module.css";
 import { AuthIcon, GameIcon, HomeIcon } from "./navigationIcons";
 import { AppLink } from "@/router/AppLink";
+import { useAuth } from "@/contexts/AuthContext"; 
+import { useNavigate } from "react-router-dom";
 
 function Navigation() {
   const [iconColor] = useState("#8c8c8cff");
+  const navigate = useNavigate();
+  const { user, loading } = useAuth();
+
+  const handleMyPageClick = () => {
+    if (loading) return; // 세션 확인 중이면 아무 것도 안 함
+    if (user) {
+      navigate("mypage");
+    } else {
+      navigate("login");
+    }
+  };
+
   return (
     <div className={S.navigation}>
       <AppLink variant={"tab"} to={"games"}>
@@ -15,7 +29,7 @@ function Navigation() {
         <HomeIcon color={iconColor} />
         <p>홈</p>
       </AppLink>
-      <button type="button">
+      <button type="button" onClick={handleMyPageClick}>
         <AuthIcon color={iconColor} />
         <p>마이페이지</p>
       </button>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,44 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import { supabase } from "@/services/supabase"; 
+
+interface AuthContextType {
+  user: User | null;
+  loading: boolean;
+}
+
+import type { User } from "@supabase/supabase-js";
+
+const AuthContext = createContext<AuthContextType>({
+  user: null,
+  loading: true,
+});
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // 최초 세션 확인
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setUser(session?.user ?? null);
+      setLoading(false);
+    });
+
+    // 로그인/로그아웃 이벤트 리스너
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, loading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext); // context 훅

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,9 +3,12 @@ import { createRoot } from "react-dom/client";
 import "./styles/global.css";
 import { RouterProvider } from "react-router-dom";
 import routes from "./router/routes";
+import { AuthProvider } from "./contexts/AuthContext"; // ← 경로 확인 필요
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <RouterProvider router={routes} />
+    <AuthProvider>
+      <RouterProvider router={routes} />
+    </AuthProvider>
   </StrictMode>
 );

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -1,0 +1,6 @@
+function Mypage() {
+  return (
+    <div>Mypage</div>
+  )
+}
+export default Mypage

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -5,6 +5,7 @@ import LetterColorPlayPage from "@/pages/Games/LetterColor/LetterColorPlayPage";
 import NumberPlayPage from "@/pages/Games/Number/NumberPlay";
 import HomePage from "@/pages/Home/HomePage";
 import Login from "@/pages/Login/Login";
+import MyPage from "@/pages/MyPage/MyPage";
 import NotFoundPage from "@/pages/NotFound/NotFoundPage";
 import NoticePage from "@/pages/Notice/NoticePage";
 import QnaPage from "@/pages/Qna/QnaPage";
@@ -48,6 +49,7 @@ const routes = createBrowserRouter([
         path: "/notice",
         element: <NoticePage />,
       },
+      { handle: { title: "마이페이지" }, path: "mypage", element: <MyPage /> },
       { handle: { title: "고객문의" }, path: "/qna", element: <QnaPage /> },
       { handle: { title: "로그인" }, path: "login", element: <Login /> },
       {


### PR DESCRIPTION
## 📌 PR 요약

- 페이지 전역에 세션여부(로그인 여부) 상태를 전역에 선언하였습니다.
- 이로 인해 유효한 세션이 남아있다면 자동로그인 처리 됩니다.
- useContext로 구현하였습니다.

- 사용법
```
import { useAuth } from "@/contexts/AuthContext";

function MyComponent() {
  const { user, loading } = useAuth();

  if (loading) {
    return <p>세션 확인 중...</p>; // 아직 세션 불러오는 중이면 대기 UI
  }

  if (!user) {
    return <p>로그인이 필요합니다.</p>; // 비로그인 상태
  }

  return (
    <div>
      <h2>{user.email}님 환영합니다!</h2>
      <p>유저 ID: {user.id}</p>
    </div>
  );
}

export default MyComponent;
```

-  사용 가능한 속성 (user 객체)
```
user.email       // 이메일 주소
user.id          // 고유 유저 ID (uuid)
user.user_metadata // 닉네임, 성별 등 추가 정보 (회원가입 시 커스텀 필드)
user.created_at  // 가입 일시
```

## ✅ 체크리스트

- [x] 해당 PR이 이슈와 연결되어 있다면, 이슈 번호를 명시했나요? (`Closes #번호`)
- [x] 기능이 정상 동작함을 확인했나요?
- [x] 팀원들과 사전에 공유된 내용인가요?
- [x] 코드 스타일 가이드(ESLint, Prettier 등)를 따랐나요?

## 📎 관련 이슈

Closes #87 

## 🧪 테스트 방법 (선택)

- 현재 로컬 스토리지에서 세션을 지운 상태입니다.
<img width="992" height="706" alt="노세션" src="https://github.com/user-attachments/assets/13befbaf-1d01-40c8-a183-5bc2c20543bf" />

<img width="995" height="707" alt="노세션2" src="https://github.com/user-attachments/assets/36deb8a3-7265-44fa-ab33-ea70f876d65c" />

: 보다시피 세션이 없는 상황 즉, 비로그인 상태에서는 마이페이지 클릭시 `로그인 페이지`로 라우팅 됩니다.

---
- 현재는 로그인 이후의 상황이므로 로컬스토리지에 세션이 존재합니다.
<img width="1009" height="705" alt="세션" src="https://github.com/user-attachments/assets/74b4e100-6387-43df-a78a-e942b4184a38" />

<img width="994" height="705" alt="세션2" src="https://github.com/user-attachments/assets/3ced4472-abf8-434b-a820-db49f0eff701" />

: 보다시피 세션이 존재하는 상황 즉, 로그인 상태에서는 마이페이지 클릭시 `마이페이지`로 라우팅 됩니다.
