### PR TITLE
[feat] 보너스 점수 계산 커스텀 훅 (#91)

### DIFF
--- a/src/hooks/useBonusScore.tsx
+++ b/src/hooks/useBonusScore.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react';
+
+export function useScore(sec: number) {
+  const ref = useRef<NodeJS.Timeout | null>(null); // 타이머 저장
+  const scoreRef = useRef<number>(100);            // 실시간 점수
+  const resultRef = useRef<number | null>(null);    // 최종 점수 고정
+  const unit = 100 / sec;                          // 초당 감소량
+
+  // 타이머 시작
+  useEffect(() => {
+    ref.current = setInterval(() => {
+      scoreRef.current = Math.max(0, scoreRef.current - unit);
+    }, 1000);
+
+    return () => {
+      if (ref.current) {
+        clearInterval(ref.current);
+        ref.current = null;
+      }
+    };
+  }, [unit]);
+
+  // get: 점수 반환 + 타이머 정지
+  const get = () => {
+    if (resultRef.current === null) {
+      resultRef.current = Math.floor(scoreRef.current); // 현재 점수 고정
+      if (ref.current) {
+        clearInterval(ref.current); // 타이머 정지
+        ref.current = null;
+      }
+    }
+    return resultRef.current;
+  };
+
+  return { get };
+}
+
+const { get } = useScore(30); // 30초 기준 타이머 바로 시작됨
+
+// 나중에 점수 필요할 때
+const score = get(); // get() 호출 시 현재 점수 반환 + 타이머 종료


### PR DESCRIPTION
## 📌 PR 요약

- 보너스 점수를 계산하는 훅을 만들었습니다.
- 최대한 간편하게 만들었고 
- 리렌더링과 무관하고 정확하게 계산하기 위해 ref로 처리했습니다.

- 사용법
<img width="511" height="100" alt="보너스점수 사용법" src="https://github.com/user-attachments/assets/59ac6098-b277-44d0-80c3-ba30efed9ece" />

: 게임 시작시 훅을 선언하면, 그때부터 타이머가 내부적으로 흐르게 됩니다.
: 인풋으로 넣은 최대시간(듀레이션)을 기준으로 100점에서 시작해 1초마다 보너스 점수가 갱신이 됩니다.

: 예) 30초를 넣고 선언하면 100점에서 시작해서 초당 3.3점씩 감소하게 됩니다.  
: 게임 종료시 get()으로 그동안 계산된 보너스 점수를 반환 받을 수 있으며 소수점이 잘린 정수 형태로 받게 됩니다. 
: 이걸 본 점수와 합쳐서 결과창에 출력하면 됩니다.

## ✅ 체크리스트

- [x] 해당 PR이 이슈와 연결되어 있다면, 이슈 번호를 명시했나요? (`Closes #번호`)
- [ ] 기능이 정상 동작함을 확인했나요?
- [x] 팀원들과 사전에 공유된 내용인가요?
- [x] 코드 스타일 가이드(ESLint, Prettier 등)를 따랐나요?

## 📎 관련 이슈

Closes #91 

## 🧪 테스트 방법 (선택)

아직 완성된 게임이 없어서 테스트는 못해봤습니다.
