### PR TITLE
[fix] 회원가입 크로스 디바이스 구현 (#180)

### DIFF
--- a/src/hooks/useSignUp.tsx
+++ b/src/hooks/useSignUp.tsx
@@ -5,7 +5,13 @@ export function useSignUp() {
   const [loading, setLoading] = useState<boolean>(false); // 로딩 상태
   const [error, setError] = useState<string | null>(null); // 에러 상태
 
-  const signUp = async (email: string, password: string) => {
+  const signUp = async (
+    email: string, 
+    password: string,
+    nickname: string,
+    gender?: "male" | "female" | "other" | null,
+    birth?: string | null
+  ) => {
     setLoading(true);
     setError(null);
 
@@ -15,6 +21,11 @@ export function useSignUp() {
         password,
         options: {
           emailRedirectTo: "http://localhost:3000/post-sign-up", // 이메일 인증 후 리디렉션 주소
+          data: {
+            nickname,
+            gender,
+            birth
+          }
         },
       });
 
@@ -36,4 +47,5 @@ export function useSignUp() {
   };
   return { signUp, loading, error };
 }
+
 export default useSignUp;

--- a/src/pages/SignUp/PostSignUp.tsx
+++ b/src/pages/SignUp/PostSignUp.tsx
@@ -18,30 +18,16 @@ function PostSignUp() {
         return;
       }
 
-      // 2. 로컬 프로필 정보 확인
-      const pendingRaw = localStorage.getItem("pending-profile");
+      // 2. User Metadata에서 프로필 정보 확인
+      const { nickname, gender, birth } = user.user_metadata || {};
 
-      if (!pendingRaw) {
-        console.warn("⚠️ 로컬 저장된 프로필 없음");
+      if (!nickname) {
+        console.warn("⚠️ User Metadata에 닉네임 없음");
         navigate("/", { replace: true });
         return;
       }
 
-      let pendingProfile = null;
-      try {
-        pendingProfile = JSON.parse(pendingRaw);
-      } catch (parseErr) {
-        console.error("❌ 프로필 JSON 파싱 실패:", parseErr);
-        navigate("/", { replace: true });
-        return;
-      }
-
-      if (!pendingProfile.nickname) {
-        console.warn("⚠️ 닉네임 누락: 잘못된 프로필 데이터");
-        localStorage.removeItem("pending-profile");
-        navigate("/", { replace: true });
-        return;
-      }
+      console.log("✅ User Metadata 확인:", { nickname, gender, birth });
 
       // 3. 기존 프로필 존재 여부 확인
       const { data: existingProfile, error: checkError } = await supabase
@@ -56,24 +42,27 @@ function PostSignUp() {
         return;
       }
 
-      // 4. insert
+      // 4. insert (기존 프로필이 없을 때만)
       if (!existingProfile) {
         try {
           await insertProfile({
             id: user.id,
-            nickname: pendingProfile.nickname,
-            gender: pendingProfile.gender ?? null,
-            birth: pendingProfile.birth ?? null,
+            nickname: nickname,
+            gender: gender ?? null,
+            birth: birth ?? null,
             avatar_url: null,
             email: user.email,
           });
+          
+          console.log("✅ 프로필 생성 완료");
         } catch (err) {
           console.error("❌ 프로필 저장 실패 상세 에러:", err);
         }
+      } else {
+        console.log("ℹ️ 이미 프로필이 존재함");
       }
 
-      // 5. 정리 및 홈 이동
-      localStorage.removeItem("pending-profile");
+      // 5. 홈으로 이동
       navigate("/", { replace: true });
     };
 
@@ -81,25 +70,25 @@ function PostSignUp() {
   }, []);
 
   return (
-  <main
-    style={{
-      flex: 1,
-      backgroundColor: "#FFC260",
-      display: "flex",
-      flexDirection: "column",
-      justifyContent: "center",
-      alignItems: "center",
-      textAlign: "center",
-      padding: "2rem",
-      color: "#333",
-    }}
-  >
-    <h1 style={{ fontSize: "2rem", marginBottom: "1rem" }}>계정 활성화 중...</h1>
-    <p style={{ fontSize: "1.1rem" }}>
-      잠시만 기다려주세요. 자동으로 홈으로 이동합니다.
-    </p>
-  </main>
-);
+    <main
+      style={{
+        flex: 1,
+        backgroundColor: "#FFC260",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+        textAlign: "center",
+        padding: "2rem",
+        color: "#333",
+      }}
+    >
+      <h1 style={{ fontSize: "2rem", marginBottom: "1rem" }}>계정 활성화 중...</h1>
+      <p style={{ fontSize: "1.1rem" }}>
+        잠시만 기다려주세요. 자동으로 홈으로 이동합니다.
+      </p>
+    </main>
+  );
 }
 
 export default PostSignUp;

--- a/src/pages/SignUp/PostSignUp.tsx
+++ b/src/pages/SignUp/PostSignUp.tsx
@@ -27,7 +27,6 @@ function PostSignUp() {
         return;
       }
 
-      console.log("✅ User Metadata 확인:", { nickname, gender, birth });
 
       // 3. 기존 프로필 존재 여부 확인
       const { data: existingProfile, error: checkError } = await supabase

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -4,7 +4,6 @@ import Input from "@/common/form/Input";
 import SubmitButton from "@/common/form/SubmitButton";
 import useSignUp from "@/hooks/useSignUp";
 import { useState } from "react";
-import { insertProfile } from "@/utils/insertProfile";
 import { useNavigate } from "react-router-dom";
 
 function SignUp() {
@@ -59,17 +58,13 @@ function SignUp() {
 
     setFieldErrors({}); // 기존 에러 초기화
 
-    const result = await signUp(email, password);
+    // 🔥 User Metadata와 함께 회원가입
+    const result = await signUp(email, password, nickname, gender, birth);
 
     if (result) {
-      // 프로필 데이터 localStorage에 저장
-      const profileData = {
-        nickname,
-        gender,
-        birth,
-      };
-      localStorage.setItem("pending-profile", JSON.stringify(profileData));
-
+      // 🎉 localStorage 저장 제거 - User Metadata로 처리!
+      console.log("✅ 회원가입 성공 - 메타데이터와 함께 저장됨");
+      
       // 팬딩 안내 페이지로 이동
       navigate("/pending-email", { replace: true, state: { email } });
     } else {

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -58,13 +58,9 @@ function SignUp() {
 
     setFieldErrors({}); // 기존 에러 초기화
 
-    // 🔥 User Metadata와 함께 회원가입
     const result = await signUp(email, password, nickname, gender, birth);
 
-    if (result) {
-      // 🎉 localStorage 저장 제거 - User Metadata로 처리!
-      console.log("✅ 회원가입 성공 - 메타데이터와 함께 저장됨");
-      
+    if (result) {   
       // 팬딩 안내 페이지로 이동
       navigate("/pending-email", { replace: true, state: { email } });
     } else {


### PR DESCRIPTION
## 📌 PR 요약

- 회원가입시 리다이렉팅 주소에 메타데이터를 넣을 수 있다는 정보를 입수.
- 원래 로컬에 저장하던 닉네임, 성별, 생년월일을 메타데이터로 넣음.
- 계정 활성화 페이지에서는 메타데이터에서 해당 정보 꺼내고 profiles 테이블에 유저 정보 삽입.

## ✅ 체크리스트

- [x] 해당 PR이 이슈와 연결되어 있다면, 이슈 번호를 명시했나요? (`Closes #번호`)
- [x] 기능이 정상 동작함을 확인했나요?
- [x] 팀원들과 사전에 공유된 내용인가요?
- [x] 코드 스타일 가이드(ESLint, Prettier 등)를 따랐나요?

## 📎 관련 이슈

Closes #180 

## 🧪 테스트 방법 (선택)

- 회원가입하고 다른 브라우저(Edge)로 이메일 인증을 함.
: 정상 회원가입 확인.

- 모바일로 이메일 인증 함.
: 아직 개발 서버라서 안됨.
: 배포 후에 확인 가능할 듯.

