### PR TITLE
[feat] 회원가입 벨리데이션 & 이메일 대기 페이지 배경 추가 (#199)

### DIFF
--- a/src/common/form/Input.tsx
+++ b/src/common/form/Input.tsx
@@ -1,25 +1,42 @@
 import S from "../styles/form.module.css";
 
 interface Props {
-  type?:string
+  type?: string;
   placeholder: string;
   label: string;
   id: string;
-  onChange?: (e:React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
   error?: string;
   disabled?: boolean;
 }
 
 function Input({ type, placeholder, id, label, onChange, error, disabled }: Props) {
   
+  // 비밀번호 조건 메시지
+  const getHelperText = () => {
+    if (error) return error;
+    
+    if (id === "sign-up-password") {
+      return "영문자와 숫자 포함 6자 이상";
+    }
+    
+    return "\u00A0"; 
+  };
+
   return (
     <label htmlFor={id} className={S.inputContainer}>
       <p>{label}</p>
-      <input type={type} placeholder={placeholder} onChange={onChange} disabled={disabled}/>
-      <p className={S.errorMessage}>
-        {error ? error : "\u00A0" /* 공백 유니코드로 줄 유지 */}
+      <input 
+        type={type} 
+        placeholder={placeholder} 
+        onChange={onChange} 
+        disabled={disabled}
+      />
+      <p className={error ? S.errorMessage : (id === "sign-up-password" ? S.helperText : S.errorMessage)}>
+        {getHelperText()}
       </p>
     </label>
   );
 }
+
 export default Input;

--- a/src/common/styles/form.module.css
+++ b/src/common/styles/form.module.css
@@ -45,3 +45,10 @@
   margin-top: var(--space-0);
   user-select: none;
 }
+.helperText {
+  color: var(--dark-gray); 
+  font-weight: bold;  
+  font-size: var(--font-2) !important;
+  margin-top: var(--space-0);
+  user-select: none;
+}

--- a/src/pages/SignUp/components/styles/pendingEmail.module.css
+++ b/src/pages/SignUp/components/styles/pendingEmail.module.css
@@ -5,6 +5,7 @@
   align-items: center;
   flex-direction: column;
   padding: 1rem;
+  background-color: var(--main-blue);
 }
 
 .cardWrap{

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -87,7 +87,7 @@ function SignUp() {
         <Input
           type={"password"}
           placeholder={"비밀번호를 입력해주세요. (필수)"}
-          id={"password"}
+          id={"sign-up-password"}
           label={"PW"}
           onChange={(e) => setPassword(e.target.value)}
           error={fieldErrors.password}
@@ -140,6 +140,7 @@ function SignUp() {
             <input
               type="date"
               id="birth"
+              max={new Date().toISOString().split('T')[0]}
               name="birth"
               onChange={(e) => setBirth(e.target.value)}
               disabled={loading}


### PR DESCRIPTION
## 📌 PR 요약

- 회원가입에 비밀번호 조건과, 생년월일 벨리데이션을 추가했습니다.
- 이메일 대기 페이지에 배경색을 추가했습니다.

## ✅ 체크리스트

- [x] 해당 PR이 이슈와 연결되어 있다면, 이슈 번호를 명시했나요? (`Closes #번호`)
- [x] 기능이 정상 동작함을 확인했나요?
- [x] 팀원들과 사전에 공유된 내용인가요?
- [x] 코드 스타일 가이드(ESLint, Prettier 등)를 따랐나요?

## 📎 관련 이슈

Closes #200 
Closes #199 

## 🧪 테스트 방법 (선택)

직접 테스트해본 방법이 있다면 설명해주세요.
<img width="640" height="943" alt="테스트" src="https://github.com/user-attachments/assets/befbee26-cd3f-4e09-9269-55bf59e01c17" />
