### PR TITLE
[fix] 안드로이드 모바일 환경에서 게임중 input focus 유지 및 네비게이션바 렌더 토글 (#192)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,6 @@ function App() {
   const currentMatch = matches[matches.length - 1];
   if (!currentMatch.handle) return;
   const currentTitle = (currentMatch.handle as RouteHandle).title || "뇌하수체";
-  console.log(isKeyboardOpen);
 
   return (
     <>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useMatches } from "react-router-dom";
 import Header from "./common/layout/Header";
 import Navigation from "./common/layout/Navigation";
+import { useKeyBoard } from "./contexts/KeyboardContext";
 
 interface RouteHandle {
   title?: string;
@@ -8,9 +9,12 @@ interface RouteHandle {
 
 function App() {
   const matches = useMatches();
+  const { isKeyboardOpen } = useKeyBoard();
   const currentMatch = matches[matches.length - 1];
   if (!currentMatch.handle) return;
   const currentTitle = (currentMatch.handle as RouteHandle).title || "뇌하수체";
+  console.log(isKeyboardOpen);
+
   return (
     <>
       <main className="global-container">
@@ -18,7 +22,7 @@ function App() {
         <div className="outlet-wrapper">
           <Outlet />
         </div>
-        <Navigation />
+        {!isKeyboardOpen && <Navigation />}
       </main>
     </>
   );

--- a/src/contexts/KeyboardContext.tsx
+++ b/src/contexts/KeyboardContext.tsx
@@ -1,0 +1,69 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+interface KeyboardContextType {
+  isKeyboardOpen: boolean;
+}
+
+const KeyboardContext = createContext<KeyboardContextType>({
+  isKeyboardOpen: false,
+});
+
+export const KeyboardProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [isKeyboardOpen, setIsKeyboardOpen] = useState(false);
+  const [isInputFocused, setIsInputFocused] = useState(false);
+  //아이패드 제외
+  const isMobile = /iPhone|iPod|Android/i.test(navigator.userAgent);
+
+  useEffect(() => {
+    if (!isMobile) return;
+
+    const onFocusIn = (e: FocusEvent) => {
+      const target = e.target as Element;
+      if (target.matches("input, textarea")) {
+        setIsKeyboardOpen(true);
+        setIsInputFocused(true);
+      }
+    };
+    const onFocusOut = (e: FocusEvent) => {
+      const target = e.target as Element;
+      if (target.matches("input, textarea")) {
+        setIsKeyboardOpen(false);
+        setIsInputFocused(false);
+      }
+    };
+
+    document.addEventListener("focusin", onFocusIn);
+    document.addEventListener("focusout", onFocusOut);
+    return () => {
+      document.removeEventListener("focusin", onFocusIn);
+      document.removeEventListener("focusout", onFocusOut);
+    };
+  }, [isMobile]);
+
+  useEffect(() => {
+    if (!isMobile) return;
+
+    const onResize = () => {
+      // 키보드가 올라오면 innerHeight가 줄어듭니다
+      if (isInputFocused) return;
+      const heightDiff =
+        window.innerHeight < document.documentElement.clientHeight;
+      setIsKeyboardOpen(heightDiff);
+    };
+
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [isMobile, isInputFocused]);
+
+  return (
+    <KeyboardContext.Provider value={{ isKeyboardOpen }}>
+      {children}
+    </KeyboardContext.Provider>
+  );
+};
+
+export const useKeyBoard = () => useContext(KeyboardContext);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,8 @@ import { createRoot } from "react-dom/client";
 import "./styles/global.css";
 import { RouterProvider } from "react-router-dom";
 import routes from "./router/routes";
-import { AuthProvider } from "./contexts/AuthContext"; 
+import { AuthProvider } from "./contexts/AuthContext";
+import { KeyboardProvider } from "./contexts/KeyboardContext";
 
 const KAKAO_JAVASCRIPT_KEY = import.meta.env.VITE_KAKAO_JAVASCRIPT_KEY;
 
@@ -16,7 +17,9 @@ if (window.Kakao && !window.Kakao.isInitialized()) {
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <AuthProvider>
-      <RouterProvider router={routes} />
+      <KeyboardProvider>
+        <RouterProvider router={routes} />
+      </KeyboardProvider>
     </AuthProvider>
   </StrictMode>
 );

--- a/src/pages/Games/common/SubmitAnswer.tsx
+++ b/src/pages/Games/common/SubmitAnswer.tsx
@@ -20,6 +20,7 @@ function SubmitAnswer({ placeholder, onSubmit }: Props) {
     if (value) {
       onSubmit(value); // 부모로 전달
       inputRef.current!.value = ""; // 입력 초기화
+      inputRef.current!.focus(); //입력 후 자동 포커스
     }
   };
 


### PR DESCRIPTION
## 📌 PR 요약

- 무엇을 구현하거나 수정했는지 요약해주세요.
- 안드로이드 환경에서 발생한 문제
1. 게임중 정답입력 input focus가 계속 풀림
2. 네비게이션바에 input창이 가려져 입력이 어려움

- 해결
- 제출후 입력 초기화할때 focus도 추가
- 가상 키보드가 열려있는지 체크해 네비게이션 바 토글
조건처리  모바일 환경인가 체크 -> input에 포커스가 되어있는지 체크 -> 스크린의 resizing이 일어났는지 체크
모두 true일때 가상키보드가 열려있다고 생각해서 네비게이션바가 사라집니다.

- 문제점
게임 입력창 뿐만아니라 모든 input,textarea에 focus되었을때 네비게이션바가 사라짐
안드로이드 환경에서 가상키보드는 없는데 input에 포커스 되어있을때 네비게이션바가 사라져있음

## ✅ 체크리스트

- [ ] 해당 PR이 이슈와 연결되어 있다면, 이슈 번호를 명시했나요? (`Closes #번호`)
- [ ] 기능이 정상 동작함을 확인했나요?
- [ ] 팀원들과 사전에 공유된 내용인가요?
- [ ] 코드 스타일 가이드(ESLint, Prettier 등)를 따랐나요?

## 📎 관련 이슈

Closes #192 

## 🧪 테스트 방법 (선택)

직접 테스트해본 방법이 있다면 설명해주세요.
