### PR TITLE
[Refactor] 로더를 통한 데이터 패칭 (#244)

### DIFF
--- a/src/api/service/game/getAllGames.ts
+++ b/src/api/service/game/getAllGames.ts
@@ -7,6 +7,7 @@ export interface GameEntry {
   name: string;
   game_url: string | null;
   description: string;
+  img_url:string;
 }
 
 // 모든 게임 목록을 가져오는 API 함수

--- a/src/api/service/game/getAllGames.ts
+++ b/src/api/service/game/getAllGames.ts
@@ -1,0 +1,23 @@
+import { supabase } from "@/api/service/supabase/supabase";
+
+// supabase games 테이블 전체 컬럼 타입.
+// 추후 path 컬럼 추가해야 함.
+export interface GameEntry {
+  game_id: number;
+  name: string;
+  game_url: string | null;
+  description: string;
+}
+
+// 모든 게임 목록을 가져오는 API 함수
+export async function getAllGames(): Promise<GameEntry[]> {
+  const { data, error } = await supabase
+    .from("games")
+    .select("*");
+
+  if (error) {
+    throw new Error(`게임 데이터 조회 실패: ${error.message}`);
+  }
+
+  return data as GameEntry[];
+}

--- a/src/api/service/game/getAllGames.ts
+++ b/src/api/service/game/getAllGames.ts
@@ -1,11 +1,10 @@
 import { supabase } from "@/api/service/supabase/supabase";
 
 // supabase games 테이블 전체 컬럼 타입.
-// 추후 path 컬럼 추가해야 함.
 export interface GameEntry {
   game_id: number;
   name: string;
-  game_url: string | null;
+  segment: string | null;
   description: string;
   img_url:string;
 }

--- a/src/pages/Games/index.tsx
+++ b/src/pages/Games/index.tsx
@@ -1,25 +1,58 @@
+import { useParams, useLoaderData } from "react-router-dom";
+import { GameEntry } from "@/api/service/game/getAllGames";
 import S from "./gamePage.module.css";
 import { AppLink } from "@/router/AppLink";
 import runNeuro from "@/assets/images/pages/game/run_neuro_cloud.svg";
+import LetterColorGamePage from "./LetterColor";
+import NumberPlayPage from "./Number";
+import ChoseongPlayPage from "./Choseong";
+import NotFoundPage from "@/pages/NotFound";
 
 function GamesPage() {
-  return (
-    <>
+  const { gameType } = useParams<{ gameType: string }>();
+  const games = useLoaderData() as GameEntry[];
+
+  // gameType이 없으면 게임 선택 페이지 렌더링
+  if (!gameType) {
+    // 게임 목록이 없을 때
+    if (!games || games.length === 0) {
+      return <div>게임이 없습니다.</div>;
+    }
+
+    return (
       <div className={S.container}>
         <img src={runNeuro} alt="" />
         <div className={S.anchors}>
-          <AppLink variant={"page"} to={"numbers"} className={S.link}>
-            숫자를 외워라!
-          </AppLink>
-          <AppLink variant={"page"} to={"choseong"} className={S.link}>
-            초성 퀴즈
-          </AppLink>
-          <AppLink variant={"page"} to={"letter-color"} className={S.link}>
-            색깔을 맞춰라!
-          </AppLink>
+          {games.map((game) => {
+            const gameLink = game.segment || "";
+            
+            return (
+              <AppLink 
+                key={game.game_id}
+                variant={"page"} 
+                to={gameLink} 
+                className={S.link}
+              >
+                {game.name}
+              </AppLink>
+            );
+          })}
         </div>
       </div>
-    </>
-  );
+    );
+  }
+
+  // gameType이 있으면 해당 게임 렌더링
+  switch (gameType) {
+    case "letter-color":
+      return <LetterColorGamePage />;
+    case "numbers":
+      return <NumberPlayPage />;
+    case "choseong":
+      return <ChoseongPlayPage />;
+    default:
+      return <NotFoundPage errorMessage="존재하지 않는 게임입니다." />;
+  }
 }
+
 export default GamesPage;

--- a/src/pages/Home/components/GameCard.tsx
+++ b/src/pages/Home/components/GameCard.tsx
@@ -16,16 +16,16 @@ export function GameCard({
   description,
   linkTo,
   onIconClick,
-  isLoading = false,
+  
 }: Props) {
   const descriptionLines = description.split("@");
 
   return (
-    <div className={`${S.card} ${isLoading ? S.loading : ""}`}>
+    <div className={S.card}>
       <button
         className={S.iconButton}
         onClick={onIconClick}
-        disabled={isLoading}
+        
       >
         <svg
           width="25"
@@ -94,12 +94,11 @@ export function GameCard({
       <img
         src={imageSrc}
         alt={title}
-        className={isLoading ? S.loadingImage : ""}
       />
-      <p className={`${S.gameTitle} ${isLoading ? S.loadingText : ""}`}>
+      <p className={S.gameTitle}>
         {title}
       </p>
-      <div className={`${S.gameDescription} ${isLoading ? S.loadingText : ""}`}>
+      <div className={S.gameDescription}>
         {descriptionLines.map((line, idx) => (
           <p key={idx}>{line}</p>
         ))}
@@ -107,7 +106,7 @@ export function GameCard({
       <AppLink
         variant="page"
         to={linkTo}
-        className={`${S.link} ${isLoading ? S.loadingLink : ""}`}
+        className={S.link}
       >
         <p>시작하기</p>
       </AppLink>

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -8,28 +8,7 @@ import GameCard from "./components/GameCard";
 import S from "./homePage.module.css";
 import img from "@/assets/images/pages/home/home_img.svg";
 
-// 이미지들을 import로 가져오기
-import numberGameImg from "@/assets/images/pages/game/number_game.svg";
-import wordGameImg from "@/assets/images/pages/game/word_game.svg";
-import letterColorGameImg from "@/assets/images/pages/game/letterColor_game.svg";
-
 import type { HomeLoaderData } from "@/router/loaders/homePageLoader";
-
-// 이미지 & 라우팅 경로 설정
-const gameMetaMap: Record<string, { image: string; path: string }> = {
-  "숫자를 외워라!": {
-    image: numberGameImg,
-    path: "/games/numbers",
-  },
-  "초성 퀴즈": {
-    image: wordGameImg,
-    path: "/games/choseong",
-  },
-  "색깔을 맞춰라!": {
-    image: letterColorGameImg,
-    path: "/games/letter-color",
-  },
-};
 
 function HomePage() {
   // 로더에서 데이터 가져오기
@@ -46,7 +25,7 @@ function HomePage() {
     setIsOpen(false);
     setSelectedGame({ id: gameId, name });
   };
-  
+
   // selectedGame이 업데이트되고 랭킹 로딩이 완료되면 모달 오픈.
   useEffect(() => {
     if (selectedGame && !rankingLoading) {
@@ -67,14 +46,15 @@ function HomePage() {
         {gamesError && <p>에러 발생: {gamesError}</p>}
 
         {games?.map((game) => {
-          const meta = gameMetaMap[game.name];
+          // game.game_url은 완전한 URL이라고 가정 (예: https://.../image.png)
+          
           return (
             <GameCard
               key={game.game_id}
-              imageSrc={meta?.image ?? ""}
+              imageSrc={game.img_url}
               title={game.name}
               description={game.description}
-              linkTo={meta?.path ?? "/games"}
+              linkTo={"/games"} // 나중에 slug 기반 동적 라우팅으로 교체 예정
               onIconClick={() => handleOpenRanking(game.game_id, game.name)}
               isLoading={false} // 로더에서 데이터를 가져왔으므로 항상 false
             />

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -46,8 +46,6 @@ function HomePage() {
         {gamesError && <p>에러 발생: {gamesError}</p>}
 
         {games?.map((game) => {
-          // game.game_url은 완전한 URL이라고 가정 (예: https://.../image.png)
-          
           return (
             <GameCard
               key={game.game_id}
@@ -56,7 +54,6 @@ function HomePage() {
               description={game.description}
               linkTo={"/games"} // 나중에 slug 기반 동적 라우팅으로 교체 예정
               onIconClick={() => handleOpenRanking(game.game_id, game.name)}
-              isLoading={false} // 로더에서 데이터를 가져왔으므로 항상 false
             />
           );
         })}

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,16 +1,19 @@
+// src/pages/HomePage/HomePage.tsx
+import { useLoaderData } from "react-router";
+import { useEffect, useState } from "react";
+import { useAllRankingData } from "@/hooks/useAllRankingData";
 import Footer from "./components/Footer";
 import RankingModal from "@/common/modals/Ranking/RankingModal";
-import { useEffect, useState } from "react";
-import { useAllGames } from "@/hooks/useAllGames";
-import { useAllRankingData } from "@/hooks/useAllRankingData";
+import GameCard from "./components/GameCard";
 import S from "./homePage.module.css";
 import img from "@/assets/images/pages/home/home_img.svg";
-import GameCard from "./components/GameCard";
 
 // 이미지들을 import로 가져오기
 import numberGameImg from "@/assets/images/pages/game/number_game.svg";
 import wordGameImg from "@/assets/images/pages/game/word_game.svg";
 import letterColorGameImg from "@/assets/images/pages/game/letterColor_game.svg";
+
+import type { HomeLoaderData } from "@/router/loaders/homePageLoader";
 
 // 이미지 & 라우팅 경로 설정
 const gameMetaMap: Record<string, { image: string; path: string }> = {
@@ -28,18 +31,14 @@ const gameMetaMap: Record<string, { image: string; path: string }> = {
   },
 };
 
-// 기본 게임 데이터 (스켈레톤용)
-const defaultGames = [
-  { game_id: 1, name: "숫자를 외워라!", description: "숫자를 기억하고@순서대로 맞춰보세요" },
-  { game_id: 2, name: "초성 퀴즈", description: "초성을 보고@단어를 맞춰보세요" },
-  { game_id: 3, name: "색깔을 맞춰라!", description: "색깔을 기억하고@순서대로 맞춰보세요" },
-];
-
 function HomePage() {
+  // 로더에서 데이터 가져오기
+  const { games, error: gamesError } = useLoaderData() as HomeLoaderData;
+
   const [isOpen, setIsOpen] = useState(false);
   const [selectedGame, setSelectedGame] = useState<{ id: number; name: string } | null>(null);
 
-  const { games, loading: gamesLoading, error: gamesError } = useAllGames();
+  // 랭킹 데이터는 모달용이므로 기존 훅 유지
   const { rankings, loading: rankingLoading } = useAllRankingData(selectedGame?.id ?? 0);
 
   // 랭킹 데이터를 가져오는 로직을 분리합니다.
@@ -60,9 +59,6 @@ function HomePage() {
     setSelectedGame(null); // 모달정보 초기화.
   };
 
-  // 로딩 중이거나 에러가 있을 때는 기본 게임 데이터 사용
-  const displayGames = gamesLoading || gamesError ? defaultGames : games;
-
   return (
     <div className={S.container}>
       <main className={S.main}>
@@ -70,7 +66,7 @@ function HomePage() {
 
         {gamesError && <p>에러 발생: {gamesError}</p>}
 
-        {displayGames?.map((game) => {
+        {games?.map((game) => {
           const meta = gameMetaMap[game.name];
           return (
             <GameCard
@@ -80,7 +76,7 @@ function HomePage() {
               description={game.description}
               linkTo={meta?.path ?? "/games"}
               onIconClick={() => handleOpenRanking(game.game_id, game.name)}
-              isLoading={gamesLoading}
+              isLoading={false} // 로더에서 데이터를 가져왔으므로 항상 false
             />
           );
         })}

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -52,7 +52,7 @@ function HomePage() {
               imageSrc={game.img_url}
               title={game.name}
               description={game.description}
-              linkTo={"/games"} // 나중에 slug 기반 동적 라우팅으로 교체 예정
+              linkTo={`/games/${game.segment}`}
               onIconClick={() => handleOpenRanking(game.game_id, game.name)}
             />
           );

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,42 +1,28 @@
 import { AppLink } from "@/router/AppLink";
 import S from "./myPage.module.css";
 import noticeNeuro from "@/assets/images/pages/notice/notice_neuro.svg";
-import { useEffect, useState } from "react";
 import UserProfile from "./components/UserProfile";
 import MyRanking from "./components/MyRanking";
 import { useAuth } from "@/contexts/AuthContext";
 import NotFoundPage from "../NotFound";
-import { supabase } from "@/api/service/supabase/supabase";
 import Swal from "sweetalert2";
 import { useLocation, useNavigate } from "react-router";
 import Spinner from "@/common/layout/Spinner";
-import { useAllGames } from "@/hooks/useAllGames"; // 추가
-import {
-  getNoticeList,
-  type NoticeList,
-} from "@/api/service/notice/getNoticeData";
+import { useLoaderData } from "react-router-dom";
+import type { Notice } from "@/api/service/notice/getNoticeData";
+import type { GameEntry } from "@/api/service/game/getAllGames";
+import { supabase } from "@/api/service/supabase/supabase";
 
 function Mypage() {
   const navigate = useNavigate();
-
-  const { user, userProfile } = useAuth();
-
-  const [noticeList, setNoticeList] = useState<NoticeList | null>(null);
-  // 동적으로 게임 목록 가져오기
-  const { games, loading: gamesLoading, error: gamesError } = useAllGames();
-
   const location = useLocation();
   const from = location.state?.from?.pathname || "/";
 
-  useEffect(() => {
-    const fetchNoticeData = async () => {
-      const data = await getNoticeList();
-      const notice = data?.filter((_, index) => index === 0);
-      setNoticeList(notice!);
-    };
-
-    fetchNoticeData();
-  }, [user]);
+  const { user, userProfile } = useAuth();
+  const { latestNotice, games } = useLoaderData() as {
+    latestNotice: Notice[];
+    games: GameEntry[];
+  };
 
   const handleLogout = () => {
     Swal.fire({
@@ -58,21 +44,13 @@ function Mypage() {
     return <NotFoundPage errorMessage={"유저 정보를 찾을 수 없습니다."} />;
   }
 
-  if (!userProfile || !noticeList || gamesLoading) {
+  if (!userProfile) {
     return <Spinner />;
-  }
-
-  if (gamesError) {
-    return (
-      <NotFoundPage
-        errorMessage={`게임 정보를 불러오는데 실패했습니다: ${gamesError}`}
-      />
-    );
   }
 
   return (
     <div className={S.container}>
-      {noticeList?.map((item) => (
+      {latestNotice.map((item) => (
         <AppLink
           variant={"page"}
           to={"/notice"}
@@ -93,7 +71,7 @@ function Mypage() {
         />
 
         <div className={S.rankingContainer}>
-          {games?.map((game) => (
+          {games.map((game) => (
             <MyRanking
               key={game.game_id}
               userId={userProfile.id}

--- a/src/pages/Notice/index.tsx
+++ b/src/pages/Notice/index.tsx
@@ -1,31 +1,20 @@
 import { AppLink } from "@/router/AppLink";
-import PostCard from "../../common/post/PostCard";
+import PostCard from "@/common/post/PostCard";
 import S from "./notice.module.css";
 import qnaIcon from "@/assets/icons/qna.svg";
-import { useEffect, useState } from "react";
-import {
-  getNoticeList,
-  type NoticeList,
-} from "@/api/service/notice/getNoticeData";
+import { useState } from "react";
+import { useLoaderData } from "react-router-dom";
+import type { NoticeList } from "@/api/service/notice/getNoticeData";
 import Spinner from "@/common/layout/Spinner";
 
 function NoticePage() {
+  const noticeList = useLoaderData() as NoticeList | null;
   const [openCardId, setOpenCardId] = useState<number | null>(null);
-  const [noticeList, setNoticeList] = useState<NoticeList | null>(null);
 
   const onChangeToggle = (id: number) => {
     setOpenCardId((prevId) => (prevId === id ? null : id));
   };
-  useEffect(() => {
-    const fetchNoticeData = async () => {
-      const data = await getNoticeList();
-      setNoticeList(data);
-    };
 
-    fetchNoticeData();
-  }, []);
-
-  useEffect(() => {}, [openCardId]);
   return (
     <div className={S.wrapper}>
       <div className={S.container}>

--- a/src/pages/Qna/index.tsx
+++ b/src/pages/Qna/index.tsx
@@ -2,27 +2,19 @@ import { AppLink } from "@/router/AppLink";
 import PostCard from "@/common/post/PostCard";
 import S from "./qna.module.css";
 import postIcon from "@/assets/icons/post.svg";
-import { useEffect, useState } from "react";
-import { getQnaList, type QnaList } from "@/api/service/qna/getQnaListData";
+import { useState } from "react";
+import { useLoaderData } from "react-router-dom";
+import type { QnaList } from "@/api/service/qna/getQnaListData";
 import Spinner from "@/common/layout/Spinner";
 
 function QnaPage() {
+  const qnaList = useLoaderData() as QnaList | null;
   const [openCardId, setOpenCardId] = useState<number | null>(null);
-  const [qnaList, setQnaList] = useState<QnaList | null>(null);
+
   const onChangeToggle = (id: number) => {
     setOpenCardId((prevId) => (prevId === id ? null : id));
   };
 
-  useEffect(() => {
-    const fetchQnaData = async () => {
-      const data = await getQnaList();
-      setQnaList(data);
-    };
-
-    fetchQnaData();
-  }, []);
-
-  useEffect(() => {}, [openCardId]);
   return (
     <div className={S.wrapper}>
       <div className={S.container}>

--- a/src/router/loaders/gamePageLoader.ts
+++ b/src/router/loaders/gamePageLoader.ts
@@ -1,0 +1,3 @@
+export default function gamePageLoader() {
+  
+}

--- a/src/router/loaders/gamePageLoader.ts
+++ b/src/router/loaders/gamePageLoader.ts
@@ -1,3 +1,11 @@
-export default function gamePageLoader() {
-  
+import { getAllGames } from "@/api/service/game/getAllGames"
+
+export async function gamePageLoader() {
+  try {
+    const games = await getAllGames();
+    return games;
+  } catch (error) {
+    console.error("게임 로더 에러:", error);
+    throw error;
+  }
 }

--- a/src/router/loaders/homePageLoader.ts
+++ b/src/router/loaders/homePageLoader.ts
@@ -3,9 +3,9 @@ import { getAllGames, type GameEntry } from "@/api/service/game/getAllGames";
 
 // 기본 게임 데이터 (에러 시 fallback용)
 const defaultGames: GameEntry[] = [
-  { game_id: 1, name: "숫자를 외워라!", game_url: null, description: "숫자를 기억하고@순서대로 맞춰보세요" ,img_url : ""},
-  { game_id: 2, name: "초성 퀴즈", game_url: null, description: "초성을 보고@단어를 맞춰보세요" ,img_url : ""},
-  { game_id: 3, name: "색깔을 맞춰라!", game_url: null, description: "색깔을 기억하고@순서대로 맞춰보세요" ,img_url : ""},
+  { game_id: 1, name: "숫자를 외워라!", segment: null, description: "숫자를 기억하고@순서대로 맞춰보세요" ,img_url : ""},
+  { game_id: 2, name: "초성 퀴즈", segment: null, description: "초성을 보고@단어를 맞춰보세요" ,img_url : ""},
+  { game_id: 3, name: "색깔을 맞춰라!", segment: null, description: "색깔을 기억하고@순서대로 맞춰보세요" ,img_url : ""},
 ];
 
 export async function homePageLoader({ request }: LoaderFunctionArgs) {

--- a/src/router/loaders/homePageLoader.ts
+++ b/src/router/loaders/homePageLoader.ts
@@ -1,0 +1,34 @@
+import type { LoaderFunctionArgs } from "react-router";
+import { getAllGames, type GameEntry } from "@/api/service/game/getAllGames";
+
+// 기본 게임 데이터 (에러 시 fallback용)
+const defaultGames: GameEntry[] = [
+  { game_id: 1, name: "숫자를 외워라!", game_url: null, description: "숫자를 기억하고@순서대로 맞춰보세요" },
+  { game_id: 2, name: "초성 퀴즈", game_url: null, description: "초성을 보고@단어를 맞춰보세요" },
+  { game_id: 3, name: "색깔을 맞춰라!", game_url: null, description: "색깔을 기억하고@순서대로 맞춰보세요" },
+];
+
+export async function homePageLoader({ request }: LoaderFunctionArgs) {
+  try {
+    const games = await getAllGames();
+
+    return {
+      games,
+      error: null,
+    };
+  } catch (error) {
+    console.error("홈 로더 에러:", error);
+    
+    // API 에러 메시지 추출
+    const errorMessage = error instanceof Error ? error.message : "게임 데이터를 불러오는데 실패했습니다.";
+    
+    // 에러가 발생해도 기본 게임 데이터로 fallback
+    return {
+      games: defaultGames,
+      error: errorMessage,
+    };
+  }
+}
+
+// 로더 데이터 타입 export (컴포넌트에서 사용)
+export type HomeLoaderData = Awaited<ReturnType<typeof homePageLoader>>;

--- a/src/router/loaders/homePageLoader.ts
+++ b/src/router/loaders/homePageLoader.ts
@@ -3,9 +3,9 @@ import { getAllGames, type GameEntry } from "@/api/service/game/getAllGames";
 
 // 기본 게임 데이터 (에러 시 fallback용)
 const defaultGames: GameEntry[] = [
-  { game_id: 1, name: "숫자를 외워라!", game_url: null, description: "숫자를 기억하고@순서대로 맞춰보세요" },
-  { game_id: 2, name: "초성 퀴즈", game_url: null, description: "초성을 보고@단어를 맞춰보세요" },
-  { game_id: 3, name: "색깔을 맞춰라!", game_url: null, description: "색깔을 기억하고@순서대로 맞춰보세요" },
+  { game_id: 1, name: "숫자를 외워라!", game_url: null, description: "숫자를 기억하고@순서대로 맞춰보세요" ,img_url : ""},
+  { game_id: 2, name: "초성 퀴즈", game_url: null, description: "초성을 보고@단어를 맞춰보세요" ,img_url : ""},
+  { game_id: 3, name: "색깔을 맞춰라!", game_url: null, description: "색깔을 기억하고@순서대로 맞춰보세요" ,img_url : ""},
 ];
 
 export async function homePageLoader({ request }: LoaderFunctionArgs) {

--- a/src/router/loaders/myPageLoader.ts
+++ b/src/router/loaders/myPageLoader.ts
@@ -1,3 +1,26 @@
-export default function myPageLoader() {
-  
+import { supabase } from "@/api/service/supabase/supabase";
+import { getAllGames } from "@/api/service/game/getAllGames";
+import type { GameEntry } from "@/api/service/game/getAllGames";
+import type { Notice } from "@/api/service/notice/getNoticeData";
+
+export async function myPageLoader(): Promise<{
+  latestNotice: Notice[];
+  games: GameEntry[];
+}> {
+  const { data: noticeData, error: noticeError } = await supabase
+    .from("notices")
+    .select("*")
+    .order("created_at", { ascending: false })
+    .limit(1);
+
+  if (noticeError) {
+    throw new Response("공지사항 불러오기 실패", { status: 500 });
+  }
+
+  const games = await getAllGames();
+
+  return {
+    latestNotice: noticeData ?? [],
+    games,
+  };
 }

--- a/src/router/loaders/myPageLoader.ts
+++ b/src/router/loaders/myPageLoader.ts
@@ -1,0 +1,3 @@
+export default function myPageLoader() {
+  
+}

--- a/src/router/loaders/noticePageLoader.ts
+++ b/src/router/loaders/noticePageLoader.ts
@@ -1,3 +1,6 @@
-export default function noticePageLoader() {
-  
+import { getNoticeList } from "@/api/service/notice/getNoticeData";
+
+export async function noticePageLoader() {
+  const data = await getNoticeList();
+  return data;
 }

--- a/src/router/loaders/noticePageLoader.ts
+++ b/src/router/loaders/noticePageLoader.ts
@@ -1,0 +1,3 @@
+export default function noticePageLoader() {
+  
+}

--- a/src/router/loaders/qnaPageLoader.ts
+++ b/src/router/loaders/qnaPageLoader.ts
@@ -1,3 +1,6 @@
-export default function qnaPageLoader() {
-  
+import { getQnaList } from "@/api/service/qna/getQnaListData";
+
+export async function qnaPageLoader() {
+  const data = await getQnaList();
+  return data;
 }

--- a/src/router/loaders/qnaPageLoader.ts
+++ b/src/router/loaders/qnaPageLoader.ts
@@ -1,0 +1,3 @@
+export default function qnaPageLoader() {
+  
+}

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -20,12 +20,15 @@ import QnaWritePage from "@/pages/Qna/write";
 import SharePage from "@/pages/Games/Share";
 import ResetPasswordPending from "@/pages/FindAccount/components/ResetPasswordPending";
 
+
+import { homePageLoader } from "@/router/loaders/homePageLoader";
+
 const routes = createBrowserRouter([
   {
     path: "/",
     element: <App />,
     children: [
-      { handle: { title: "뇌하수체" }, path: "", element: <HomePage /> },
+      { handle: { title: "뇌하수체" }, path: "", element: <HomePage />, loader: homePageLoader},
       {
         path: "games",
         element: <GamesLayout />,

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -1,16 +1,12 @@
 import { createBrowserRouter } from "react-router-dom";
 import App from "@/App";
 import HomePage from "@/pages/Home";
-import GamesLayout from "@/pages/Games/GamesLayout";
 import GamesPage from "@/pages/Games";
-import LetterColorPlayPage from "@/pages/Games/LetterColor/index";
 import NoticePage from "@/pages/Notice/index";
 import QnaPage from "@/pages/Qna/index";
 import MyPage from "@/pages/MyPage";
 import PendingEmail from "@/pages/SignUp/components/PendingEmail";
 import SignUp from "@/pages/SignUp";
-import ChoseongPlayPage from "@/pages/Games/Choseong/index";
-import NumberPlayPage from "@/pages/Games/Number/index";
 import NotFoundPage from "@/pages/NotFound";
 import FindAccount from "@/pages/FindAccount";
 import Login from "@/pages/Login";
@@ -20,61 +16,56 @@ import QnaWritePage from "@/pages/Qna/write";
 import SharePage from "@/pages/Games/Share";
 import ResetPasswordPending from "@/pages/FindAccount/components/ResetPasswordPending";
 
-
 import { homePageLoader } from "@/router/loaders/homePageLoader";
+import { gamePageLoader } from "@/router/loaders/gamePageLoader";
+import { qnaPageLoader } from "@/router/loaders/qnaPageLoader";
+import { noticePageLoader } from "@/router/loaders/noticePageLoader";
+import { myPageLoader } from "@/router/loaders/myPageLoader";
 
 const routes = createBrowserRouter([
   {
     path: "/",
     element: <App />,
     children: [
-      { handle: { title: "뇌하수체" }, path: "", element: <HomePage />, loader: homePageLoader},
+      { 
+        handle: { title: "뇌하수체" },
+        path: "", 
+        element: <HomePage />, 
+        loader: homePageLoader
+      },
       {
-        path: "games",
-        element: <GamesLayout />,
-        children: [
-          {
-            handle: {
-              title: "게임",
-            },
-            path: "",
-            element: <GamesPage />,
-          },
-          {
-            handle: {
-              title: "색깔을 맞춰라",
-            },
-            path: "letter-color",
-            element: <LetterColorPlayPage />,
-          },
-          {
-            handle: { title: "숫자를 외워라" },
-            path: "numbers",
-            element: <NumberPlayPage />,
-          },
-          {
-            handle: { title: "초성 퀴즈" },
-            path: "Choseong",
-            element: <ChoseongPlayPage />,
-          },
-          {
-            handle: { title: "게임 결과 공유" },
-            path: "share/:rankingId",
-            element: <SharePage />,
-          },
-        ].filter(Boolean),
+        handle: { title: "게임" },
+        path: "games/:gameType?",
+        element: <GamesPage />,
+        loader: gamePageLoader,
+      },
+      {
+        handle: { title: "게임 결과 공유" },
+        path: "games/share/:rankingId",
+        element: <SharePage />,
       },
       {
         handle: { title: "공지사항" },
         path: "notice",
         element: <NoticePage />,
+        loader: noticePageLoader,
       },
-      { handle: { title: "마이페이지" }, path: "mypage", element: <MyPage /> },
+      { 
+        handle: { title: "마이페이지" },
+        path: "mypage", 
+        loader: myPageLoader,
+        element: <MyPage /> 
+      },
       {
         path: "qna",
         element: <QnaLayout />,
         children: [
-          { handle: { title: "고객문의" }, path: "", element: <QnaPage /> },
+          { 
+            handle: { title: "고객문의" },
+            path: "",
+            loader: qnaPageLoader, 
+            element: <QnaPage /> 
+          },
           {
             handle: { title: "문의작성" },
             path: "write",
@@ -82,7 +73,11 @@ const routes = createBrowserRouter([
           },
         ],
       },
-      { handle: { title: "로그인" }, path: "login", element: <Login /> },
+      { 
+        handle: { title: "로그인" },
+        path: "login", 
+        element: <Login /> 
+      },
       {
         handle: { title: "계정찾기" },
         path: "find-account",
@@ -93,7 +88,11 @@ const routes = createBrowserRouter([
         path: "pending-email",
         element: <PendingEmail />,
       },
-      { handle: { title: "회원가입" }, path: "sign-up", element: <SignUp /> },
+      { 
+        handle: { title: "회원가입" },
+        path: "sign-up", 
+        element: <SignUp /> 
+      },
       {
         handle: { title: "계정활성화" },
         path: "post-sign-up",


### PR DESCRIPTION
## 📌 PR 요약

- 초기 데이터가 필요한 페이지들에 로더를 만들어 초기 데이터들을 패칭하도록 만들었습니다.
- 해당 페이지들은 다음과 같습니다.
1. 홈페이지
2. 게임페이지
3. 마이페이지
4. 공지사항
5. 고객센터

- 확실히 패칭 코드가 분할되어 컴포넌트의 가독성이 좋아졌습니다.

# 다만 너무 많은 곳을 고쳤기에 충돌이 날까 우려가 됩니다..

- 제가 개발서버로 돌려보았을때는 문제가 없었는데 혹시 문제를 발견한다면 즉시 연락하십시오.

## ✅ 체크리스트

- [x] 해당 PR이 이슈와 연결되어 있다면, 이슈 번호를 명시했나요? (`Closes #번호`)
- [x] 기능이 정상 동작함을 확인했나요?
- [x] 팀원들과 사전에 공유된 내용인가요?
- [x] 코드 스타일 가이드(ESLint, Prettier 등)를 따랐나요?

## 📎 관련 이슈

Closes #244 

## 🧪 테스트 방법 (선택)

직접 테스트해본 방법이 있다면 설명해주세요.
